### PR TITLE
ロゴでHOMEに戻るように修正

### DIFF
--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -180,7 +180,7 @@ p {
   }
   #app_title_user {
     position: absolute;
-    top: 50%;
+    top: 55%;
     left: 0;
     transform: translate(-10%, -50%);
     @include mq-down(sm) {
@@ -205,22 +205,6 @@ p {
       }
     }
   }
-  #user_top_nav_user {
-    position: absolute;
-    top: 8%;
-    right: 2%;
-    @include mq-down(lg) {
-      top: 8%;
-      right: 2%;
-    }
-    li {
-      text-shadow: 2px 2px 2px black;
-    }
-    li:hover {
-      font-weight: bold;
-      text-shadow: none;
-    }
-  }
   .menu_open_btn {
     position: absolute;
     top: 5%;
@@ -230,6 +214,14 @@ p {
       top: 25px;
       right: 20px;
     }
+  }
+}
+
+#top_nav_user {
+  width: 100%;
+  height: 50px;
+  li:hover {
+    text-decoration: underline;
   }
 }
 
@@ -281,7 +273,7 @@ p {
 
 #margin_wrapper {
   width: 100%;
-  height: 150px;
+  height: 200px;
   @include mq-down(md) {
     height: 100px;
   }
@@ -857,11 +849,8 @@ p {
   #shop_nav {
     position: absolute;
     top: 0;
-    left: 0;
-    p {
-      text-shadow: 1px 1px 1px black;
-      line-height: 35px;
-    }
+    right: 0;
+    height: 50px;
     .dd_menu {
       display: flex;
       justify-content: flex-start;
@@ -870,15 +859,12 @@ p {
       padding: 0;
       li {
         position: relative;
-        background: rgba(0, 0, 0, 0.7);
-        width: 120px;
-        height: 30px;
-        line-height: 30px;
+        width: 125px;
+        height: 50px;
+        line-height: 50px;
         text-align: center;
         @include mq-down(lg) {
-          width: 100px;
-          height: 25px;
-          line-height: 25px;
+          width: 120px;
         }
         .dd_menu_sub {
           position: absolute;
@@ -887,25 +873,29 @@ p {
         }
         .dd_menu_sub.open {
           display: block;
-          li a {
-            display: block;
-            width: 100%;
-            color: #fff;
-            text-align: center;
-          }
-          li a:hover {
-            background: #ff5500;
+          li {
+            height: 40px;
+            a {
+              display: block;
+              width: 100%;
+              height: 100%;
+              line-height: 40px;
+              text-align: center;
+            }
           }
         }
+        #dd_li_last {
+          display: block;
+          width: 100%;
+        }
       }
-      #dd_li_last {
-        display: block;
-        width: 100%;
-      }
-      #dd_li_last:hover {
-        background: #ff5500;
-        i {
-          color: white;
+      .dd_short_li {
+        width: 95px;
+        li {
+          width: 100%;
+          a {
+            width: 100%;
+          }
         }
       }
     }
@@ -950,19 +940,9 @@ p {
   }
   #user_top_nav {
     position: absolute;
-    top: 5%;
-    right: 2%;
-    @include mq-down(lg) {
-      top: 5%;
-      right: 0;
-    }
-    li {
-      text-shadow: 2px 2px 2px black;
-    }
-    li:hover {
-      font-weight: bold;
-      text-shadow: none;
-    }
+    top: 0%;
+    right: 0%;
+    height: 50px;
   }
   #modal_btn {
     width: 150px;

--- a/app/views/fee_guides/_guide_top_shop.html.erb
+++ b/app/views/fee_guides/_guide_top_shop.html.erb
@@ -1,50 +1,50 @@
   <div class="flex sm:justify-center lg:justify-end items-center bg-top-image bg-cover bg-no-repeat bg-center" id="fee_guide_top">
-  <div class="hidden sm:block md:w-1/2 xl:w-2/5" id="shop_nav">
-    <div class="flex justify-center items-center mx-auto">
-      <p class="text-app mt-1 text-center text-sm mr-3">【店舗アカウントで閲覧中】</p>
-      <div class="mt-1 sm:mt-0 mr-3 md:mr-2">
-        <%= link_to "店舗情報編集", edit_shop_registration_path, class: "nav_btn_edit text-xxs px-2" %>
+  <div class="hidden sm:flex justify-between items-center w-full bg-app_bg" id="shop_nav">
+    <div class="h-full flex items-center pl-4">
+      <p class="hidden lg:flex text-app text-center mr-4">【店舗アカウントで閲覧中】</p>
+      <div class="flex items-center mr-2 lg:mr-3">
+        <%= link_to "店舗情報編集", edit_shop_registration_path, class: "nav_btn_edit text-xxs lg:text-xs px-2" %>
       </div>
-      <div class="mt-1 sm:mt-0 mr-3 md:mr-2">
-        <%= link_to "ログアウト", destroy_shop_session_path, method: :delete, data: {confirm: "ログアウトしますか?" }, class: "nav_btn_sign_out text-xxs px-4" %>
+      <div class="flex items-center¥">
+        <%= link_to "ログアウト", destroy_shop_session_path, method: :delete, data: {confirm: "ログアウトしますか?" }, class: "nav_btn_sign_out text-xxs lg:text-xs px-4" %>
       </div>
     </div>
     <div class="flex justify-center">
-      <ul class="dd_menu flex justify-center mt-1">
-        <li class="text-white text-xxs lg:text-xs">
-          <i class="fas fa-couch text-app mr-1"></i>ルーム料金<i class="fas fa-chevron-down text-white ml-1"></i>
+      <ul class="dd_menu flex justify-center">
+        <li class="text-xs hover:text-app mx-1">
+          <i class="fas fa-couch text-app mr-1"></i>ルーム料金<i class="fas fa-chevron-down ml-1"></i>
           <ul class="dd_menu_sub">
-            <li class="text-xxs lg:text-xs text-white">
+            <li class="text-xs bg-app_bg hover:text-app">
               <%= link_to "ルーム料金一覧", main_plans_path %>
             </li>
-            <li class="text-xxs lg:text-xs text-white">
+            <li class="text-xs bg-app_bg hover:text-app">
               <%= link_to "ルーム料金登録", new_main_plan_path, id: "dd_menu_last" %>
             </li>
           </ul>
         </li>
-        <li class="text-white text-xxs lg:text-xs">
-          <i class="fas fa-coffee text-app mr-1"></i>ドリンク料金<i class="fas fa-chevron-down text-white ml-1"></i>
+        <li class="text-xs hover:text-app mx-1">
+          <i class="fas fa-coffee text-app mr-1"></i>ドリンク料金<i class="fas fa-chevron-down ml-1"></i>
           <ul class="dd_menu_sub">
-            <li class="text-xxs lg:text-xs text-white">
+            <li class="text-xs bg-app_bg hover:text-app">
               <%= link_to "ドリンク料金一覧", drink_plans_path %>
             </li>
-            <li class="text-xxs lg:text-xs text-white">
+            <li class="text-xs bg-app_bg hover:text-app">
               <%= link_to "ドリンク料金登録", new_drink_plan_path, id: "dd_menu_last" %>
             </li>
           </ul>
         </li>
-        <li class="text-white text-xs lg:text-sm">
-          <i class="fas fa-info-circle text-app mr-1"></i>TOPICS<i class="fas fa-chevron-down text-white ml-1"></i>
+        <li class="text-xs hover:text-app dd_short_li">
+          <i class="fas fa-info-circle text-app mr-1"></i>TOPICS<i class="fas fa-chevron-down ml-1"></i>
           <ul class="dd_menu_sub">
-            <li class="text-xxs lg:text-xs text-white">
+            <li class="text-xs bg-app_bg hover:text-app">
               <%= link_to "TOPICS一覧", shops_topics_path %>
             </li>
-            <li class="text-xxs lg:text-xs text-white">
+            <li class="text-xs bg-app_bg hover:text-app">
               <%= link_to "TOPICS投稿", new_shops_topic_path, id: "dd_menu_last" %>
             </li>
           </ul>
         </li>
-        <li class="text-white text-xs lg:text-sm">
+        <li class="text-xs dd_short_li hover:text-app mr-2 lg:mr-5">
           <%= link_to(fee_guides_path, id: "dd_li_last") do %>
             <i class="fas fa-list-alt text-app mr-1 ml-1"></i>
             案内履歴
@@ -54,12 +54,14 @@
     </div>
   </div>
   <div class="w-1/2 xl:w-2/5" id="app_concept">
-    <div class="w-1/2 xl:w-2/5" id="app_title">
-      <div class="md:mr-20 xl:mr-12">
-        <h1 class="text-white text-center sm:text-base md:text-lg lg:text-2xl mb-1 sm:mb-3">カラオケ料金案内アプリ</h1>
-        <p class="text-app text-center text-5xl sm:text-6xl md:text-7xl lg:text-8xl">iko!KARA</p>
+    <%= link_to root_path do %>
+      <div class="w-1/2 xl:w-2/5" id="app_title">
+        <div class="md:mr-20 xl:mr-12">
+          <h1 class="text-center text-white sm:text-base md:text-lg lg:text-2xl mb-1 sm:mb-3">カラオケ料金案内アプリ</h1>
+          <p class="text-app text-center text-5xl sm:text-6xl md:text-7xl lg:text-8xl">iko!KARA</p>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
   <div>
     <button id="modal_btn" class="focus:outline-none hidden sm:block p-2 bg-black bg-opacity-70 hover:bg-app rounded-full ring-8 ring-app" type="button">

--- a/app/views/fee_guides/_guide_top_user.html.erb
+++ b/app/views/fee_guides/_guide_top_user.html.erb
@@ -1,32 +1,34 @@
 <div class="flex sm:justify-center lg:justify-end items-center bg-top-image bg-cover bg-no-repeat bg-center" id="fee_guide_top">
-  <div class="w-1/2 xl:w-2/5 pr-4 sm:pr-0" id="app_title">
-    <div class="md:mr-20 xl:mr-12">
-      <h1 class="text-white text-center md:text-lg lg:text-2xl mb-1 sm:mb-3">カラオケ料金案内アプリ</h1>
-      <p class="text-app text-center text-4xl sm:text-6xl md:text-7xl lg:text-8xl">iko!KARA</p>
+  <%= link_to root_path do %>
+    <div class="w-1/2 xl:w-2/5 pr-4 sm:pr-0" id="app_title">
+      <div class="md:mr-20 xl:mr-12">
+        <h1 class="text-white text-center text-xs md:text-base lg:text-2xl mb-1 sm:mb-3">カラオケ料金案内アプリ</h1>
+        <p class="text-app text-center text-4xl sm:text-6xl md:text-7xl lg:text-8xl">iko!KARA</p>
+      </div>
     </div>
-  </div>
-  <ul class="hidden sm:flex" id="user_top_nav">
-    <li class="text-white px-2 md:px-4 sm:text-sm lg:text-base hover:underline">
+  <% end %>
+  <ul class="w-full bg-app_bg hidden sm:flex justify-end items-center" id="user_top_nav">
+    <li class="px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
       <%= link_to "トピックス", users_topics_path %>
     </li>
-    <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
       <%= link_to "クーポン", static_pages_coupon_path %>
     </li>
-    <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
       <%= link_to "飲み放題", static_pages_alcohol_plan_path %>
     </li>
     <% if user_signed_in? %>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base  hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm  hover:underline">
         <%= link_to "マイページ", user_path(current_user.id) %>
       </li>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: {confirm: "ログアウトしますか?" } %>
       </li> 
     <% else %>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
         <%= link_to "ログイン", new_user_session_path %>
       </li>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
         <%= link_to "【ユーザー登録】", new_user_registration_path %>
       </li>
     <% end %>

--- a/app/views/layouts/_header_shop.html.erb
+++ b/app/views/layouts/_header_shop.html.erb
@@ -1,5 +1,7 @@
 <nav class="flex justify-between md:justify-start items-center w-full" id="gnav">
-  <img src="/assets/logo.png" class="hidden md:block" id="logo_md">
+  <%= link_to root_path do %>
+    <img src="/assets/logo.png" class="hidden md:block" id="logo_md">
+  <% end %>
   <div class="" id="nav_main">
     <div class="md:flex items-center border-b border-gray-300 mr-2" id="account">
       <div class="h-full flex items-center md:mx-5">

--- a/app/views/layouts/_header_user.html.erb
+++ b/app/views/layouts/_header_user.html.erb
@@ -1,39 +1,43 @@
+<ul class="hidden sm:flex justify-end items-center bg-gray-600" id="top_nav_user">
+  <li class="text-white px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <%= link_to "ホーム", root_path %>
+  </li>
+  <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <%= link_to "トピックス", users_topics_path %>
+  </li>
+  <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <%= link_to "クーポン", static_pages_coupon_path %>
+  </li>
+  <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <%= link_to "飲み放題", static_pages_alcohol_plan_path %>
+  </li>
+  <% if user_signed_in? %>
+    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+      <%= link_to "マイページ", user_path(current_user.id) %>
+    </li>
+    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+      <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: {confirm: "ログアウトしますか?" } %>
+    </li> 
+  <% else %>
+    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+      <%= link_to "ログイン", new_user_session_path %>
+    </li>
+    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+      <%= link_to "【ユーザー登録】", new_user_registration_path %>
+    </li>
+  <% end %>
+</ul>
+
 <div class="bg-top-image bg-cover bg-no-repeat bg-center" id="header_user">
+  <%= link_to root_path do %>
     <div class="w-1/2 xl:w-2/5 pr-4 md:pr-0" id="app_title_user">
-    <div class="md:mr-20 xl:mr-12">
-      <h1 class="text-white text-center text-xs sm:text-xs md:text-base lg:text-lg mb-1 md:mb-3">カラオケ料金案内アプリ</h1>
-      <p class="text-app text-center text-4xl sm:text-4xl md:text-5xl lg:text-6xl">iko!KARA</p>
+      <div class="md:mr-20 xl:mr-12">
+        <h1 class="text-white text-center text-xs md:text-base lg:text-lg mb-1">カラオケ料金案内アプリ</h1>
+        <p class="text-app text-center text-4xl sm:text-4xl md:text-5xl lg:text-6xl">iko!KARA</p>
+      </div>
     </div>
-  </div>
-  <ul class="hidden sm:flex" id="user_top_nav_user">
-    <li class="text-white px-2 md:px-4 sm:text-sm lg:text-base hover:underline">
-      <%= link_to "ホーム", root_path %>
-    </li>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-sm lg:text-base hover:underline">
-      <%= link_to "トピックス", users_topics_path %>
-    </li>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-sm lg:text-base hover:underline">
-      <%= link_to "クーポン", static_pages_coupon_path %>
-    </li>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-sm lg:text-base hover:underline">
-      <%= link_to "飲み放題", static_pages_alcohol_plan_path %>
-    </li>
-    <% if user_signed_in? %>
-      <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-sm lg:text-base hover:underline">
-        <%= link_to "マイページ", user_path(current_user.id) %>
-      </li>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
-        <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: {confirm: "ログアウトしますか?" } %>
-      </li> 
-    <% else %>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
-        <%= link_to "ログイン", new_user_session_path %>
-      </li>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base hover:underline">
-        <%= link_to "【ユーザー登録】", new_user_registration_path %>
-      </li>
-    <% end %>
-  </ul>
+  <% end %>
+
   <div class="menu_open_btn sm:hidden shadow" id="open_btn">
     <span></span>
     <span></span>

--- a/app/views/static_pages/alcohol_plan.html.erb
+++ b/app/views/static_pages/alcohol_plan.html.erb
@@ -22,6 +22,61 @@
         <th class="alcohol_head w-1/4 bg-green-100">ライト</th>
       </tr>
     </thead>
+        <tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">サワー</td>
+        <td class="alcohol_body bg-indigo-100">23種類</td>
+        <td class="alcohol_body bg-red-100">20種類</td>
+        <td class="alcohol_body bg-green-100">5種類</td>
+      </tr>
+    </tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">カクテル</td>
+        <td class="alcohol_body bg-indigo-100">25種類</td>
+        <td class="alcohol_body bg-red-100">25種類</td>
+        <td class="alcohol_body bg-green-100">4種類</td>
+      </tr>
+    </tbody>
+    </tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">ハイボール</td>
+        <td class="alcohol_body bg-indigo-100">6種類</td>
+        <td class="alcohol_body bg-red-100">3種類</td>
+        <td class="alcohol_body bg-green-100">3種類</td>
+      </tr>
+    </tbody>
+        <tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">生ビール</td>
+        <td class="alcohol_body bg-indigo-100">◯</td>
+        <td class="alcohol_body bg-red-100">◯</td>
+        <td class="alcohol_body bg-green-100">×</td>
+      </tr>
+    </tbody>
+    </tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">ワイン<span class="text-xxs sm:text-sm">(赤・白)</span></td>
+        <td class="alcohol_body bg-indigo-100">◯</td>
+        <td class="alcohol_body bg-red-100">◯</td>
+        <td class="alcohol_body bg-green-100">◯</td>
+      </tr>
+    </tbody>
+    </tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">焼酎<span class="text-xxs sm:text-sm">(芋・麦)</span></td>
+        <td class="alcohol_body bg-indigo-100">◯</td>
+        <td class="alcohol_body bg-red-100">◯</td>
+        <td class="alcohol_body bg-green-100">◯</td>
+      </tr>
+    </tbody>
+    </tbody>
+      <tr class="border-b border-gray-200 hover:bg-gray-100">
+        <td class="alcohol_body">日本酒<span class="text-xxs sm:text-sm">(冷酒・燗)</span></td>
+        <td class="alcohol_body bg-indigo-100">◯</td>
+        <td class="alcohol_body bg-red-100">×</td>
+        <td class="alcohol_body bg-green-100">×</td>
+      </tr>
+    </tbody>
     <tbody>
       <tr class="border-b border-gray-200 hover:bg-gray-100">
         <td class="alcohol_body">レッドブル</td>
@@ -46,62 +101,6 @@
         <td class="alcohol_body bg-green-100">×</td>
       </tr>
     </tbody>
-    <tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">生ビール</td>
-        <td class="alcohol_body bg-indigo-100">◯</td>
-        <td class="alcohol_body bg-red-100">◯</td>
-        <td class="alcohol_body bg-green-100">×</td>
-      </tr>
-    </tbody>
-    <tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">サワー</td>
-        <td class="alcohol_body bg-indigo-100">多い</td>
-        <td class="alcohol_body bg-red-100">多い</td>
-        <td class="alcohol_body bg-green-100">普通</td>
-      </tr>
-    </tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">カクテル</td>
-        <td class="alcohol_body bg-indigo-100">多い</td>
-        <td class="alcohol_body bg-red-100">多い</td>
-        <td class="alcohol_body bg-green-100">普通</td>
-      </tr>
-    </tbody>
-    </tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">ハイボール</td>
-        <td class="alcohol_body bg-indigo-100">多い</td>
-        <td class="alcohol_body bg-red-100">普通</td>
-        <td class="alcohol_body bg-green-100">普通</td>
-      </tr>
-    </tbody>
-    </tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">日本酒</td>
-        <td class="alcohol_body bg-indigo-100">◯</td>
-        <td class="alcohol_body bg-red-100">×</td>
-        <td class="alcohol_body bg-green-100">×</td>
-      </tr>
-    </tbody>
-    </tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">ワイン</td>
-        <td class="alcohol_body bg-indigo-100">◯</td>
-        <td class="alcohol_body bg-red-100">◯</td>
-        <td class="alcohol_body bg-green-100">◯</td>
-      </tr>
-    </tbody>
-    </tbody>
-      <tr class="border-b border-gray-200 hover:bg-gray-100">
-        <td class="alcohol_body">焼酎</td>
-        <td class="alcohol_body bg-indigo-100">◯</td>
-        <td class="alcohol_body bg-red-100">◯</td>
-        <td class="alcohol_body bg-green-100">◯</td>
-      </tr>
-    </tbody>
-
   </table>
 </div>
 
@@ -117,7 +116,7 @@
     </p>
     <p class="text-blue-600 ml-2"><i class="fas fa-chevron-down text-blue-600 mr-1"></i>ここから下のドリンク全てご注文可能</p>
     <p class="text-blue-600 ml-2">※デラックス+バラエティ+ライト</p>
-    <div class="grid md:grid-cols-2 lg:grid-cols-4">
+    <div class="grid md:grid-cols-2 xl:grid-cols-4">
       <div>
         <h4 class="list_title_deluxe bg-blue-200">レッドブルカクテル</h4>
         <p class="list_alcohol">●レッドブルウォッカ</p>
@@ -207,7 +206,7 @@
           </div>    
           <div>
             <h4 class="list_title_variety bg-red-200">カクテル</h4>
-            <div class="grid md:grid-cols-2 lg:grid-cols-4">
+            <div class="grid md:grid-cols-2 xl:grid-cols-4">
               <div>
                 <p class="list_alcohol">●ゆずジントニック</p>
                 <p class="list_alcohol">●グレフルジントニック</p>
@@ -249,7 +248,7 @@
         ワインや焼酎もご利用いただけます!!
         </p>
         <p class="text-green-600 ml-2"><i class="fas fa-chevron-down text-green-600 mr-1"></i>ここから下のドリンクがご注文可能</p>
-        <div class="grid md:grid-cols-2 lg:grid-cols-4">
+        <div class="grid md:grid-cols-2 xl:grid-cols-4">
           <div>
             <h4 class="list_title_lite bg-green-200">ハイボール</h4>
             <p class="list_alcohol">●ハイボール</p>


### PR DESCRIPTION
### 実装内容
- 全ページでロゴやアプリタイトルからHOMEへ戻れるように修正
- TOP画面のNaviを見やすくなるよう修正

### 確認事項
ローカル環境で動作を確認
`rubocop -a`を実行