### PR TITLE
パンくずリストの追加とフォーム機能の追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ gem "carrierwave", "~> 2.0"
 gem "devise"
 gem "devise-i18n"
 gem "enum_help"
+gem 'gretel'
 gem "jbuilder", "~> 2.7"
 gem "jp_prefecture"
 gem "kaminari"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
     ffi (1.15.3)
     globalid (0.5.2)
       activesupport (>= 5.0)
+    gretel (4.3.0)
+      actionview (>= 5.1, < 7.0)
+      railties (>= 5.1, < 7.0)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
@@ -298,6 +301,7 @@ DEPENDENCIES
   devise
   devise-i18n
   enum_help
+  gretel
   jbuilder (~> 2.7)
   jp_prefecture
   kaminari

--- a/app/controllers/main_plans_controller.rb
+++ b/app/controllers/main_plans_controller.rb
@@ -4,7 +4,7 @@ class MainPlansController < ApplicationController
   before_action :authenticate_shop!
 
   def index
-    @q = MainPlan.includes(:shop).ransack(params[:q])
+    @q = MainPlan.where(shop_id: current_shop.id).includes(:shop).ransack(params[:q])
     @main_plans = @q.result(distinct: true).order(id: "ASC")
   end
 

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -14,6 +14,7 @@ import 'modal.js';
 import 'navbar.js';
 import 'pagetop.js';
 import 'postcode.js';
+import 'select.js';
 import 'sidemenu.js';
 import 'stylesheets/application';
 import 'tabmenu.js';

--- a/app/javascript/select.js
+++ b/app/javascript/select.js
@@ -1,0 +1,21 @@
+document.addEventListener('turbolinks:load', function () {
+  $(function () {
+    $('#fee_guide_usage_time').on('change', function () {
+      $('#fee_guide_drink_plan').val('one_hour');
+      let selected_time = $(this).val();
+      if (selected_time == 'half_hour' || selected_time == 'one_hour') {
+        $("#fee_guide_drink_plan option[value='lite_plan']").hide();
+        $("#fee_guide_drink_plan option[value='variety_plan']").hide();
+        $("#fee_guide_drink_plan option[value='deluxe_plan']").hide();
+      } else {
+        if ($("#fee_guide_drink_plan option[value='lite_plan']").css('display') == 'block') {
+          return;
+        } else {
+          $("#fee_guide_drink_plan option[value='lite_plan']").show();
+          $("#fee_guide_drink_plan option[value='variety_plan']").show();
+          $("#fee_guide_drink_plan option[value='deluxe_plan']").show();
+        }
+      }
+    });
+  });
+});

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -27,11 +27,11 @@
 }
 
 .index_table_head {
-  @apply border border-gray-400 px-2 py-1 sm:py-3 text-white text-xs xl:text-sm font-bold;
+  @apply border border-gray-400 px-1 py-1 sm:py-3 text-white text-xs xl:text-sm font-bold;
 }
 
 .index_table_body {
-  @apply border border-gray-400 px-2 py-1 text-center text-xs xl:text-sm;
+  @apply border border-gray-400 px-1 py-1 text-center text-xs xl:text-sm;
 }
 
 .show_div_table_head {
@@ -485,12 +485,16 @@ p {
 #gnav {
   height: 90px;
   background: rgb(237, 237, 237);
-  #logo_md {
+  a {
     width: 200px;
     height: 70px;
+    #logo_md {
+      width: 100%;
+      height: auto;
+    }
   }
   #nav_main {
-    width: 100%;
+    width: calc(100% - 200px);
     height: 100%;
     @include mq-down(md) {
       width: calc(100% - 80px);
@@ -508,6 +512,11 @@ p {
       }
     }
   }
+}
+
+#logo_sign {
+  height: 100%;
+  width: auto;
 }
 
 #open_btn {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -175,7 +175,7 @@ p {
   position: relative;
   width: 100%;
   height: 150px;
-  @include mq-down(md) {
+  @include mq-down(sm) {
     height: 100px;
   }
   #app_title_user {
@@ -274,7 +274,7 @@ p {
 #margin_wrapper {
   width: 100%;
   height: 200px;
-  @include mq-down(md) {
+  @include mq-down(sm) {
     height: 100px;
   }
 }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -230,9 +230,26 @@ p {
   height: 90px;
 }
 
-#bread_crumbs {
-  width: 100%;
-  height: 50px;
+.breadcrumbs {
+  height: 30px;
+  padding-left: 40px;
+  @include mq-down(sm) {
+    display: none;
+  }
+  a {
+    width: 100%;
+    height: 100%;
+    line-height: 30px;
+    color: blue;
+    font-size: 14px;
+    text-decoration: underline;
+  }
+  a:hover {
+    color: #ff5500;
+  }
+  span {
+    font-size: 14px;
+  }
 }
 
 // メインコンテンツ部品
@@ -1360,6 +1377,7 @@ p {
 #registration_btn {
   width: 100%;
   height: 100%;
+  max-width: 500px;
 }
 
 // 料金案内フォーム

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -141,7 +141,7 @@ class FeeGuide < ApplicationRecord
     self.child_total_fee = child_main_fee + child_drink_fee
   end
 
-  # 全員の合計金額を計算
+  # 全��の合計金額を計算
   def set_total_fee
     self.total_fee = (adult_total_fee * number_of_adults) +
                      (student_total_fee * number_of_students) +
@@ -225,7 +225,7 @@ class FeeGuide < ApplicationRecord
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: time, time_unit: unit)
   end
 
-  # ルーム料金を計算
+  # ルーム料金��計算
   def calculate_main_fee(fee0, fee1, count)
     fee0 * count[0] + fee1 * count[1]
   end
@@ -237,14 +237,14 @@ class FeeGuide < ApplicationRecord
 
   # ドリンクコースの時間単位の取得
   def get_drink_unit(name)
-    if ["ワンドリンク", "ドリンクバー料���"].include?(name)
+    if ["ワンドリンク", "ドリンクバ���料���"].include?(name)
       1
     else
       0
     end
   end
 
-  # ドリンクコー����の�����ウント数を取得
+  # ドリンクコースのカウント数を取得
   def get_drink_count(name, count)
     if ["ワンドリンク", "ドリンクバー料金"].include?(name)
       1

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -225,9 +225,9 @@ class FeeGuide < ApplicationRecord
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: time, time_unit: unit)
   end
 
-  # ルーム料金��計算
-  def calculate_main_fee(fee0, fee1, count)
-    fee0 * count[0] + fee1 * count[1]
+  # ルーム料金を計算
+  def calculate_main_fee(fee_a, fee_b, count)
+    fee_a * count[0] + fee_b * count[1]
   end
 
   # ドリンクコースの種類を取得
@@ -237,7 +237,7 @@ class FeeGuide < ApplicationRecord
 
   # ドリンクコースの時間単位の取得
   def get_drink_unit(name)
-    if ["ワンドリンク", "ドリンクバ���料���"].include?(name)
+    if ["ワンドリンク", "ドリンクバー料金"].include?(name)
       1
     else
       0

--- a/app/views/fee_guides/_form_fee_guide.html.erb
+++ b/app/views/fee_guides/_form_fee_guide.html.erb
@@ -59,7 +59,7 @@
         <p class="hidden sm:block text-base md:text-lg px-2 sm:mb-1" id="step_title">ご利用時間を選んでください</p>       
       </div>
       <div class="px-2 ml-2 mt-6 sm:mt-0 xl:mb-3" id="fee_guide_select">
-        <%= f.select :usage_time, FeeGuide.usage_times_i18n.invert %>
+        <%= f.select :usage_time, FeeGuide.usage_times_i18n.invert, selected: "two_hour" %>
       </div>
       <div class="mt-4 xl:hidden">
         <p class="text-sm px-2 mt-2 mb-2" id="fee_complement"><i class="far fa-check-circle text-app mr-1"></i>3時間を超える場合はフリータイムがお得です</p>

--- a/app/views/fee_guides/_guide_top_user.html.erb
+++ b/app/views/fee_guides/_guide_top_user.html.erb
@@ -8,27 +8,27 @@
     </div>
   <% end %>
   <ul class="w-full bg-app_bg hidden sm:flex justify-end items-center" id="user_top_nav">
-    <li class="px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
+    <li class="px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "トピックス", users_topics_path %>
     </li>
-    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "クーポン", static_pages_coupon_path %>
     </li>
-    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "飲み放題", static_pages_alcohol_plan_path %>
     </li>
     <% if user_signed_in? %>
-      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm  hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
         <%= link_to "マイページ", user_path(current_user.id) %>
       </li>
-      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
         <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: {confirm: "ログアウトしますか?" } %>
       </li> 
     <% else %>
-      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
         <%= link_to "ログイン", new_user_session_path %>
       </li>
-      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs lg:text-sm hover:underline">
+      <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
         <%= link_to "【ユーザー登録】", new_user_registration_path %>
       </li>
     <% end %>

--- a/app/views/fee_guides/new.html.erb
+++ b/app/views/fee_guides/new.html.erb
@@ -10,7 +10,7 @@
 <% end %>
 
 <div id="app_guide_wrapper">
-  <div class="flex justify-center lg:justify-evenly items-center py-4 xl:py-0" id="news_wrapper">
+  <div class="flex justify-center lg:justify-evenly items-center py-4 md:py-6 xl:py-0" id="news_wrapper">
     <div id="news_left">
       <div class="hidden sm:block bg-gray-100 rounded-lg shadow-lg mb-2 p-3 pt-2" id="news_box">
         <div class="w-full rounded text-center bg-app text-white my-2 items-center sm:text-xl">

--- a/app/views/layouts/_header_shop.html.erb
+++ b/app/views/layouts/_header_shop.html.erb
@@ -1,5 +1,5 @@
 <nav class="flex justify-between md:justify-start items-center w-full" id="gnav">
-  <%= link_to root_path do %>
+  <%= link_to root_path, class: "hidden md:block" do %>
     <img src="/assets/logo.png" class="hidden md:block" id="logo_md">
   <% end %>
   <div class="" id="nav_main">

--- a/app/views/layouts/_header_sign_user.html.erb
+++ b/app/views/layouts/_header_sign_user.html.erb
@@ -1,23 +1,23 @@
 <div class="bg-top-image bg-cover bg-no-repeat bg-center" id="header_user">
   <div class="w-1/2 xl:w-2/5" id="app_title_user">
     <div class="md:mr-20 xl:mr-12">
-      <h1 class="text-white text-center text-xs sm:text-sm md:text-base lg:text-lg mb-1 sm:mb-3">カラオケ料金案内アプリ</h1>
+      <h1 class="text-white text-center  text-xs md:text-base lg:text-lg mb-1 sm:mb-3">カラオケ料金案内アプリ</h1>
       <p class="text-app text-center text-4xl sm:text-4xl md:text-5xl lg:text-6xl">iko!KARA</p>
     </div>
   </div>
-  <ul class="hidden sm:flex" id="user_top_nav_user">
-    <li class="text-white px-4 hover:underline sm:text-sm lg:text-base xl:text-lg">
+  <ul class="hidden sm:flex bg-app_bg" id="user_top_nav_user">
+    <li class="px-4 hover:underline sm:text-sm lg:text-base xl:text-lg">
       <%= link_to "ホーム", root_path %>
     </li>
     <% if user_signed_in? %>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base xl:text-lg hover:underline">
+      <li class="border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base xl:text-lg hover:underline">
         <%= link_to "ログアウト", destroy_user_session_path %>
       </li> 
     <% else %>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base xl:text-lg hover:underline">
+      <li class="border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base xl:text-lg hover:underline">
         <%= link_to "ログイン", new_user_session_path %>
       </li>
-      <li class="text-white border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base xl:text-lg hover:underline">
+      <li class="border-l-2 border-gray-200 px-4 sm:text-sm lg:text-base xl:text-lg hover:underline">
         <%= link_to "【ユーザー登録】", new_user_registration_path %>
       </li>
     <% end %>

--- a/app/views/layouts/_header_user.html.erb
+++ b/app/views/layouts/_header_user.html.erb
@@ -1,28 +1,28 @@
-<ul class="hidden sm:flex justify-end items-center bg-gray-600" id="top_nav_user">
-  <li class="text-white px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+<ul class="hidden sm:flex justify-end items-center bg-app_bg shadow-lg" id="top_nav_user">
+  <li class="px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
     <%= link_to "ホーム", root_path %>
   </li>
-  <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
     <%= link_to "トピックス", users_topics_path %>
   </li>
-  <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
     <%= link_to "クーポン", static_pages_coupon_path %>
   </li>
-  <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
     <%= link_to "飲み放題", static_pages_alcohol_plan_path %>
   </li>
   <% if user_signed_in? %>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
       <%= link_to "マイページ", user_path(current_user.id) %>
     </li>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: {confirm: "ログアウトしますか?" } %>
     </li> 
   <% else %>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
       <%= link_to "ログイン", new_user_session_path %>
     </li>
-    <li class="text-white border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
       <%= link_to "【ユーザー登録】", new_user_registration_path %>
     </li>
   <% end %>
@@ -32,7 +32,7 @@
   <%= link_to root_path do %>
     <div class="w-1/2 xl:w-2/5 pr-4 md:pr-0" id="app_title_user">
       <div class="md:mr-20 xl:mr-12">
-        <h1 class="text-white text-center text-xs md:text-base lg:text-lg mb-1">カラオケ料金案内アプリ</h1>
+        <h1 class="text-center text-xs md:text-base lg:text-lg mb-1">カラオケ料金案内アプリ</h1>
         <p class="text-app text-center text-4xl sm:text-4xl md:text-5xl lg:text-6xl">iko!KARA</p>
       </div>
     </div>

--- a/app/views/layouts/_header_user.html.erb
+++ b/app/views/layouts/_header_user.html.erb
@@ -32,7 +32,7 @@
   <%= link_to root_path do %>
     <div class="w-1/2 xl:w-2/5 pr-4 md:pr-0" id="app_title_user">
       <div class="md:mr-20 xl:mr-12">
-        <h1 class="text-center text-xs md:text-base lg:text-lg mb-1">カラオケ料金案内アプリ</h1>
+        <h1 class="text-white text-center text-xs md:text-base lg:text-lg mb-1">カラオケ料金案内アプリ</h1>
         <p class="text-app text-center text-4xl sm:text-4xl md:text-5xl lg:text-6xl">iko!KARA</p>
       </div>
     </div>

--- a/app/views/layouts/_header_user.html.erb
+++ b/app/views/layouts/_header_user.html.erb
@@ -1,28 +1,28 @@
 <ul class="hidden sm:flex justify-end items-center bg-app_bg shadow-lg" id="top_nav_user">
-  <li class="px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="px-2 md:px-4 sm:text-xs hover:underline">
     <%= link_to "ホーム", root_path %>
   </li>
-  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
     <%= link_to "トピックス", users_topics_path %>
   </li>
-  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
     <%= link_to "クーポン", static_pages_coupon_path %>
   </li>
-  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+  <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
     <%= link_to "飲み放題", static_pages_alcohol_plan_path %>
   </li>
   <% if user_signed_in? %>
-    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "マイページ", user_path(current_user.id) %>
     </li>
-    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "ログアウト", destroy_user_session_path, method: :delete, data: {confirm: "ログアウトしますか?" } %>
     </li> 
   <% else %>
-    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "ログイン", new_user_session_path %>
     </li>
-    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs md:text-sm hover:underline">
+    <li class="border-l-2 border-gray-200 px-2 md:px-4 sm:text-xs hover:underline">
       <%= link_to "【ユーザー登録】", new_user_registration_path %>
     </li>
   <% end %>

--- a/app/views/shops/sessions/new.html.erb
+++ b/app/views/shops/sessions/new.html.erb
@@ -1,5 +1,7 @@
 <nav class="flex justify-center items-center w-full" id="gnav">
-  <img src="/assets/logo.png" id="logo_md">
+  <%= link_to root_path do %>
+    <img src="/assets/logo.png" id="logo_sign">
+  <% end %>
 </nav>
 <div id="sign_in_wrapper">
   <h1 class="page_title">ログイン</h1>

--- a/app/views/static_pages/alcohol_plan.html.erb
+++ b/app/views/static_pages/alcohol_plan.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% content_for :header do %>
   <div class="fixed w-full top-0 left-0 z-10">
-    <%= render "layouts/header_user" %>      
+    <%= render "layouts/header_user" %>    
   </div>
 <% end %>
 <% content_for :footer do %>
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :alcohol %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div class="mt-6">
   <h2 class="w-11/12 max-w-3xl text-center mt-2 sm:mt-12 p-2 bg-app text-white mx-auto text-xl md:text-2xl">飲み放題プラン早見表</h2>
   <table class="border-collapse table-fixed w-11/12 whitespace-no-wrap bg-white mx-auto max-w-3xl" id="table_index">

--- a/app/views/static_pages/coupon.html.erb
+++ b/app/views/static_pages/coupon.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :coupon %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <% if user_signed_in? %>
   <div class="mx-auto mt-6 mb-3" id="coupon_wrapper">
     <div id="coupon_body">
@@ -54,14 +56,14 @@
   </div>
 <% else %>
   <div class="pb-16">
-    <div class="bg-app_bg py-5">
+    <div class="mx-4 py-5 mt-6 sm:mt-0" id="coupon_condition">
       <p class="text-center mb-4">
         クーポンをご利用いただくには
         <br>
         <span class="text-app text-xl">「ユーザー登録」</span>が必要です
       </p>
-      <div class="w-3/5 bg-app hover:bg-yellow-600 mx-auto py-2 rounded-lg flex justify-center items-center sm:mb-6">
-        <%= link_to "ユーザー登録", new_user_registration_path, class: " text-white text-center", id: "registration_btn" %>
+      <div class="w-3/5 max-w-xl bg-app hover:bg-yellow-600 mx-auto py-2 rounded-lg flex justify-center items-center sm:mb-6">
+        <%= link_to "ユーザー登録はこちら", new_user_registration_path, class: " text-white text-center", id: "registration_btn" %>
       </div>
     </div>
     <div class="">

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% content_for :header do %>
   <div class="fixed w-full top-0 left-0">
-    <%= render "layouts/header_sign_user" %>
+    <%= render "layouts/header_user" %>
   </div> 
 <% end %>
 <% content_for :footer do %>
@@ -76,3 +76,5 @@
     <% end %>
   </div>
 </div>
+
+<%= render "layouts/side_menu_user" %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :user_edit, @user %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div class="pb-20 mt-6 sm:mt-12" id="sign_wrapper">
   <h2 class="page_title">ユーザー編集</h2>
   <div class="sm:border-2 border-app rounded-xl sm:shadow-lg sm:w-5/6 mx-auto py-3 sm:py-9 max-w-3xl sm:mb-6">
@@ -71,7 +73,7 @@
         </div>
       </div>
       <div class="actions mt-6 w-11/12 sm:w-2/3 mx-auto flex justify-center">
-        <%= f.submit "ユーザー編集", class: "text-sm bg-green-500 hover:bg-green-700 text-white px-2 py-2 rounded cursor-pointer w-full" %>
+        <%= f.submit "編集", class: "text-sm bg-green-500 hover:bg-green-700 text-white px-2 py-2 rounded cursor-pointer w-full" %>
       </div>
     <% end %>
   </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% content_for :header do %>
   <div class="fixed w-full top-0 left-0">
-    <%= render "layouts/header_sign_user" %>
+    <%= render "layouts/header_user" %>
   </div> 
 <% end %>
 <% content_for :footer do %>
@@ -11,7 +11,7 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
-<div class="pb-20 mt-6 sm:mt-12" id="sign_wrapper">
+<div class="pb-24 sm:pb-12" id="sign_wrapper">
   <h2 class="page_title">ユーザー登録</h2>
   <div class="sm:border-2 border-app rounded-xl sm:shadow-lg  sm:w-5/6 mx-auto py-3 sm:py-9 max-w-3xl sm:mb-6">
     <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
@@ -55,5 +55,7 @@
     <% end %>
   </div>
 </div>
+
+<%= render "layouts/side_menu_user" %>
 
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :user_sign_up %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div class="pb-24 sm:pb-12" id="sign_wrapper">
   <h2 class="page_title">ユーザー登録</h2>
   <div class="sm:border-2 border-app rounded-xl sm:shadow-lg  sm:w-5/6 mx-auto py-3 sm:py-9 max-w-3xl sm:mb-6">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :user_sign_in %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div class="pb-6" id="sign_wrapper">
   <h1 class="page_title">ログイン</h1>
   <div class="sm:border-2 border-app rounded-xl sm:shadow-lg  sm:w-5/6 mx-auto px-3 py-3 sm:py-8 max-w-xl">

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 <% content_for :header do %>
   <div class="fixed w-full top-0 left-0">
-    <%= render "layouts/header_sign_user" %>
+    <%= render "layouts/header_user" %>
   </div> 
 <% end %>
 <% content_for :footer do %>
@@ -41,3 +41,5 @@
     </div>
   </div>
 </div>
+
+<%= render "layouts/side_menu_user" %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :user_show, @user %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div class="pb-20" id="sign_wrapper">
   <div class="sm:border-2 border-app rounded-xl sm:shadow-lg sm:w-5/6 mx-auto pb-5 sm:py-4 max-w-3xl sm:mb-6">
       <div class="flex justify-center mx-auto">

--- a/app/views/users/topics/index.html.erb
+++ b/app/views/users/topics/index.html.erb
@@ -12,6 +12,8 @@
 
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :topic_index %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div id="main_contents_user">
   <h1 class="page_title mb-6">TOPICS一覧</h1>
   <%= render "topics_index_user" %>

--- a/app/views/users/topics/show.html.erb
+++ b/app/views/users/topics/show.html.erb
@@ -11,6 +11,8 @@
 <% end %>
 
 <div id="margin_wrapper"></div>
+<% breadcrumb :topic_show %>
+<%= breadcrumbs separator: " &rsaquo; " %> 
 <div class="mx-auto" id="main_contents_user">
   <div class="w-11/12 border border-gray-200 mx-auto rounded-xl mt-6 mb-t" id="topic_show">
     <div class="w-1/2 bg-app-light rounded-full text-center font-semibold text-white px-2 py-2 mx-auto my-4" >

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,0 +1,28 @@
+crumb :root do
+  link "Home", root_path
+end
+
+# crumb :projects do
+#   link "Projects", projects_path
+# end
+
+# crumb :project do |project|
+#   link project.name, project_path(project)
+#   parent :projects
+# end
+
+# crumb :project_issues do |project|
+#   link "Issues", project_issues_path(project)
+#   parent :project, project
+# end
+
+# crumb :issue do |issue|
+#   link issue.title, issue_path(issue)
+#   parent :project_issues, issue.project
+# end
+
+# If you want to split your breadcrumbs configuration over multiple files, you
+# can create a folder named `config/breadcrumbs` and put your configuration
+# files there. All *.rb files (e.g. `frontend.rb` or `products.rb`) in that
+# folder are loaded and reloaded automatically when you change them, just like
+# this file (`config/breadcrumbs.rb`).

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -1,15 +1,46 @@
 crumb :root do
-  link "Home", root_path
+  link "HOME", root_path
 end
 
-# crumb :projects do
-#   link "Projects", projects_path
-# end
+crumb :topic_index do
+  link "トピックス一覧", users_topics_path
+  parent :root
+end
 
-# crumb :project do |project|
-#   link project.name, project_path(project)
-#   parent :projects
-# end
+crumb :topic_show do
+  link "トピックス詳細", users_topics_path
+  parent :topic_index
+end
+
+crumb :coupon do
+  link "クーポン", static_pages_coupon_path
+  parent :root
+end
+
+crumb :alcohol do
+  link "飲み放題", static_pages_alcohol_plan_path
+  parent :root
+end
+
+crumb :user_sign_in do
+  link "ログイン", new_user_session_path
+  parent :root
+end
+
+crumb :user_sign_up do
+  link "ユーザー登録", new_user_registration_path
+  parent :root
+end
+
+crumb :user_show do |user|
+  link "マイページ", user_path(user)
+  parent :root
+end
+
+crumb :user_edit do |user|
+  link "ユーザー編集"
+  parent :user_show, user
+end
 
 # crumb :project_issues do |project|
 #   link "Issues", project_issues_path(project)


### PR DESCRIPTION
### 実装内容
- `gretel`を追加してインストール
   - ユーザー用のビューにパンくずリストを追加
-  料金案内フォームに、利用時間によってドリンクコースの選択肢を動的に変化させる機能を追加

### 確認事項
- ローカル環境で動作を確認
- `rubocop -a` を実行