### PR TITLE
DrinkPlanモデルのカラムの見直し

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,6 @@ Metrics/AbcSize:
   # The ABC size is a calculated magnitude, so this number can be a Fixnum or
   # a Float.
   Max: 25
+
+ClassAndModuleChildren:
+  EnforcedStyle: compact

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "carrierwave", "~> 2.0"
 gem "devise"
 gem "devise-i18n"
 gem "enum_help"
-gem 'gretel'
+gem "gretel"
 gem "jbuilder", "~> 2.7"
 gem "jp_prefecture"
 gem "kaminari"

--- a/app/controllers/drink_plans_controller.rb
+++ b/app/controllers/drink_plans_controller.rb
@@ -37,6 +37,7 @@ class DrinkPlansController < ApplicationController
   end
 
   def drink_plan_params
-    params.require(:drink_plan).permit(:name, :note, :time_unit, :adult_fee, :student_fee, :senior_fee, :child_fee)
+    params.require(:drink_plan).permit(:fee_type, :base_time, :note, :adult_fee, :student_fee, :senior_fee, :child_fee, :extension_adult_fee,
+                                       :extension_student_fee, :extension_senior_fee, :extension_child_fee)
   end
 end

--- a/app/controllers/static_pages_controller 2.rb
+++ b/app/controllers/static_pages_controller 2.rb
@@ -1,0 +1,7 @@
+class StaticPagesController < ApplicationController
+  def home; end
+
+  def coupon; end
+
+  def alcohol_plan; end
+end

--- a/app/helpers/static_pages_helper 2.rb
+++ b/app/helpers/static_pages_helper 2.rb
@@ -1,0 +1,2 @@
+module StaticPagesHelper
+end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -732,7 +732,7 @@ p {
 // 登録フォーム
 #form_wrap {
   width: 80%;
-  max-width: 600px;
+  max-width: 630px;
   margin: 0 auto;
   margin-top: 20px;
   @include mq-down(md) {
@@ -776,7 +776,7 @@ p {
         font-size: 14px;
         margin-right: 10px;
         display: inline-block;
-        width: 80px;
+        width: 100px;
         text-align: justify;
         text-align-last: justify;
       }
@@ -791,6 +791,9 @@ p {
       }
       select {
         padding-left: 5px;
+      }
+      #drink_plan_fee_type {
+        width: 150px;
       }
     }
   }

--- a/app/models/drink_plan.rb
+++ b/app/models/drink_plan.rb
@@ -22,9 +22,9 @@ class DrinkPlan < ApplicationRecord
     free_time: 1
   }
   enum base_time: {
-    half_hour: 0,
-    one_hour: 1,
-    one_half_hour: 2,
-    free_time: 3
+    base_half_hour: 0,
+    base_one_hour: 1,
+    base_one_half_hour: 2,
+    base_free_time: 3
   }
 end

--- a/app/models/drink_plan.rb
+++ b/app/models/drink_plan.rb
@@ -3,11 +3,16 @@ class DrinkPlan < ApplicationRecord
   with_options presence: true do
     validates :name
     validates :time_unit
+    validates :base_time
     with_options numericality: { only_integer: true, greater_than_or_equal_to: 0 } do
       validates :adult_fee
       validates :student_fee
       validates :senior_fee
       validates :child_fee
+      validates :extension_adult_fee
+      validates :extension_student_fee
+      validates :extension_senior_fee
+      validates :extension_child_fee
     end
   end
   validates :note, length: { maximum: 250 }
@@ -15,5 +20,11 @@ class DrinkPlan < ApplicationRecord
   enum time_unit: {
     half_hour: 0,
     free_time: 1
+  }
+  enum base_time: {
+    half_hour: 0,
+    one_hour: 1,
+    one_half_hour: 2,
+    free_time: 3
   }
 end

--- a/app/models/drink_plan.rb
+++ b/app/models/drink_plan.rb
@@ -1,9 +1,8 @@
 class DrinkPlan < ApplicationRecord
   belongs_to :shop
   with_options presence: true do
-    validates :name
-    validates :time_unit
     validates :base_time
+    validates :fee_type
     with_options numericality: { only_integer: true, greater_than_or_equal_to: 0 } do
       validates :adult_fee
       validates :student_fee
@@ -26,5 +25,11 @@ class DrinkPlan < ApplicationRecord
     base_one_hour: 1,
     base_one_half_hour: 2,
     base_free_time: 3
+  }
+  enum fee_type: {
+    drink_bar: 0,
+    lite_plan: 1,
+    variety_plan: 2,
+    deluxe_plan: 3
   }
 end

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -61,11 +61,12 @@ class FeeGuide < ApplicationRecord
 
   # 料金計算して値をセット
   def set_values
+    # 利用時間による料金カウントを取得(@count)
     @count = FeeGuide.usage_times[usage_time] + 1
     set_number_of_customers
     if usage_time == "three_hour" || usage_time == "free_time"
-      set_main_fee_free
-      set_drink_fee_free
+      set_main_fee_free_time
+      set_drink_fee_free_time
     else
       set_main_fee
       set_drink_fee
@@ -94,13 +95,13 @@ class FeeGuide < ApplicationRecord
   end
 
   # それぞれのルーム料金を計算
-  def set_main_fee_free
+  def set_main_fee_free_time
     wday = get_business_wday
     if usage_time == "three_hour"
-      time = get_div_time_three
+      time = get_div_time_three_hour
       unit = 1
     else
-      time = get_div_time_free
+      time = get_div_time_free_time
       unit = 2
     end
     chosen_free_plan = get_free_plan(wday, time, unit)
@@ -124,7 +125,7 @@ class FeeGuide < ApplicationRecord
   end
 
   # それぞれのドリンク料金を計算(3時間パック・フリータイム)
-  def set_drink_fee_free
+  def set_drink_fee_free_time
     drink_plan_name = DRINKPLAN[drink_plan]
     chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, time_unit: 1)
     self.adult_drink_fee = chosen_drink_plan.adult_fee
@@ -141,7 +142,7 @@ class FeeGuide < ApplicationRecord
     self.child_total_fee = child_main_fee + child_drink_fee
   end
 
-  # 全��の合計金額を計算
+  # グループ全体の合計金額を計算
   def set_total_fee
     self.total_fee = (adult_total_fee * number_of_adults) +
                      (student_total_fee * number_of_students) +
@@ -149,6 +150,7 @@ class FeeGuide < ApplicationRecord
                      (child_total_fee * number_of_children)
   end
 
+  # 一般/学生/シニア/小学生ごとの合計料金（ビュー表示用）
   def adult_fee_all
     adult_total_fee * number_of_adults
   end
@@ -220,7 +222,7 @@ class FeeGuide < ApplicationRecord
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: 1, time_unit: 0)
   end
 
-  # フォームで取得した内容から該当の「フリー料金を取得」
+  # フォームで取得した内容から該当の「フリータイム料金を取得」
   def get_free_plan(wday, time, unit)
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: time, time_unit: unit)
   end
@@ -230,14 +232,14 @@ class FeeGuide < ApplicationRecord
     fee_a * count[0] + fee_b * count[1]
   end
 
-  # ドリンクコースの種類を取得
+  # ドリンクコースの種類を��得
   def get_drink_name(drink_plan)
     DRINKPLAN[drink_plan]
   end
 
   # ドリンクコースの時間単位の取得
   def get_drink_unit(name)
-    if ["ワンドリンク", "ドリンクバー料金"].include?(name)
+    if ["ワンドリンク", "ドリンクバー"].include?(name)
       1
     else
       0
@@ -259,7 +261,7 @@ class FeeGuide < ApplicationRecord
   end
 
   # 3時間パックの適用が昼か夜かを取得
-  def get_div_time_three
+  def get_div_time_three_hour
     now_time = Time.zone.now
     case now_time.hour
     when 6..19
@@ -270,7 +272,7 @@ class FeeGuide < ApplicationRecord
   end
 
   # フリータイムの適用が昼か夜か夕方かを取得
-  def get_div_time_free
+  def get_div_time_free_time
     now_time = Time.zone.now
     case now_time.hour
     when 6..15

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -114,20 +114,27 @@ class FeeGuide < ApplicationRecord
 
   # それぞれのドリンク料金を計算(30分単位)
   def set_drink_fee
-    drink_plan_name = DRINKPLAN[drink_plan]
-    drink_plan_unit = get_drink_unit(drink_plan_name)
-    drink_plan_count = get_drink_count(drink_plan_name, @count)
-    chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, time_unit: drink_plan_unit)
-    self.adult_drink_fee = calculate_drink_fee(chosen_drink_plan.adult_fee, drink_plan_count)
-    self.student_drink_fee = calculate_drink_fee(chosen_drink_plan.student_fee, drink_plan_count)
-    self.senior_drink_fee = calculate_drink_fee(chosen_drink_plan.senior_fee, drink_plan_count)
-    self.child_drink_fee = calculate_drink_fee(chosen_drink_plan.child_fee, drink_plan_count)
+    if drink_plan == "one_drink"
+      self.adult_drink_fee = 0
+      self.student_drink_fee = 0
+      self.senior_drink_fee = 0
+      self.child_drink_fee = 0
+    else
+      drink_plan_name = DRINKPLAN[drink_plan]
+      drink_plan_unit = get_drink_unit(drink_plan_name)
+      drink_plan_count = get_drink_count(drink_plan_name, @count)
+      chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, time_unit: drink_plan_unit)
+      self.adult_drink_fee = calculate_drink_fee(chosen_drink_plan.adult_fee, drink_plan_count)
+      self.student_drink_fee = calculate_drink_fee(chosen_drink_plan.student_fee, drink_plan_count)
+      self.senior_drink_fee = calculate_drink_fee(chosen_drink_plan.senior_fee, drink_plan_count)
+      self.child_drink_fee = calculate_drink_fee(chosen_drink_plan.child_fee, drink_plan_count)
+    end
   end
 
   # それぞれのドリンク料金を計算(3時間パック・フリータイム)
   def set_drink_fee_free_time
     drink_plan_name = DRINKPLAN[drink_plan]
-    chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, time_unit: 1)
+    chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, base_time: 3)
     self.adult_drink_fee = chosen_drink_plan.adult_fee
     self.student_drink_fee = chosen_drink_plan.student_fee
     self.senior_drink_fee = chosen_drink_plan.senior_fee

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -114,17 +114,20 @@ class FeeGuide < ApplicationRecord
 
   # それぞれのドリンク料金を計算(30分単位)
   def set_drink_fee
-    if drink_plan == "one_drink"
+    chosen_drink_plan = DrinkPlan.find_by(fee_type: drink_plan)
+    case drink_plan
+    when "one_drink"
       self.adult_drink_fee = 0
       self.student_drink_fee = 0
       self.senior_drink_fee = 0
       self.child_drink_fee = 0
+    when "drink_bar"
+      self.adult_drink_fee = chosen_drink_plan.adult_fee
+      self.student_drink_fee = chosen_drink_plan.student_fee
+      self.senior_drink_fee = chosen_drink_plan.senior_fee
+      self.child_drink_fee = chosen_drink_plan.child_fee
     else
-      drink_plan_name = DRINKPLAN[drink_plan]
-      drink_plan_unit = get_drink_unit(drink_plan_name)
-      drink_plan_count = get_drink_count(drink_plan_name, @count)
-      chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, time_unit: drink_plan_unit)
-      self.adult_drink_fee = calculate_drink_fee(chosen_drink_plan.adult_fee, drink_plan_count)
+      self.adult_drink_fee = calculate_drink_fee(chosen_drink_plan.adult_fee, chosen_drink_plan.base_time, chosen_drink_plan.extension_adult_fee, @count)
       self.student_drink_fee = calculate_drink_fee(chosen_drink_plan.student_fee, drink_plan_count)
       self.senior_drink_fee = calculate_drink_fee(chosen_drink_plan.senior_fee, drink_plan_count)
       self.child_drink_fee = calculate_drink_fee(chosen_drink_plan.child_fee, drink_plan_count)
@@ -133,8 +136,7 @@ class FeeGuide < ApplicationRecord
 
   # それぞれのドリンク料金を計算(3時間パック・フリータイム)
   def set_drink_fee_free_time
-    drink_plan_name = DRINKPLAN[drink_plan]
-    chosen_drink_plan = DrinkPlan.find_by(name: drink_plan_name, base_time: 3)
+    chosen_drink_plan = DrinkPlan.find_by(fee_type: drink_plan, base_time: 3)
     self.adult_drink_fee = chosen_drink_plan.adult_fee
     self.student_drink_fee = chosen_drink_plan.student_fee
     self.senior_drink_fee = chosen_drink_plan.senior_fee
@@ -239,32 +241,14 @@ class FeeGuide < ApplicationRecord
     fee_a * count[0] + fee_b * count[1]
   end
 
-  # ドリンクコースの種類を��得
-  def get_drink_name(drink_plan)
-    DRINKPLAN[drink_plan]
-  end
-
-  # ドリンクコースの時間単位の取得
-  def get_drink_unit(name)
-    if ["ワンドリンク", "ドリンクバー"].include?(name)
-      1
-    else
-      0
-    end
-  end
-
-  # ドリンクコースのカウント数を取得
-  def get_drink_count(name, count)
-    if ["ワンドリンク", "ドリンクバー料金"].include?(name)
-      1
-    else
-      count
-    end
-  end
-
   # ドリンク料金を計算
-  def calculate_drink_fee(drink_fee, count)
-    drink_fee * count
+  def calculate_drink_fee(base_fee, base_time, extension_fee, count)
+    base_time_count = base_time + 1
+    if count <= base_time_count
+      base_fee
+    else
+      base_fee + (extension_fee * (count - base_time_count))
+    end
   end
 
   # 3時間パックの適用が昼か夜かを取得

--- a/app/views/drink_plans/_form_drink_plans.html.erb
+++ b/app/views/drink_plans/_form_drink_plans.html.erb
@@ -1,15 +1,17 @@
 <div class="sm:border-2 rounded-lg sm:shadow my-4 p-1 sm:p-8" id="form_wrap">
   <%= form_with model: @drink_plan, local: true do |f| %>
-    <div id="l_name">
-      <i class="fas fa-caret-square-right text-blue-600"></i>
-      <%= f.label :name %>
-      <%= f.text_field :name, required: true %>
+    <div id="l_div">
+      <div class="form_box">
+        <i class="fas fa-caret-square-right text-blue-600"></i>
+        <%= f.label :fee_type %>
+        <%= f.select :fee_type, DrinkPlan.fee_types_i18n.invert %>
+      </div>
     </div>
     <div id="l_div">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
-        <%= f.label :time_unit %>
-        <%= f.select :time_unit, DrinkPlan.time_units_i18n.invert, class: "time_unit_select" %>
+        <%= f.label :base_time %>
+        <%= f.select :base_time, DrinkPlan.base_times_i18n.invert %>
       </div>
     </div>
     <div id="l_fee">
@@ -20,8 +22,18 @@
       </div>
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
+        <%= f.label :extension_adult_fee %>
+        <%= f.text_field :extension_adult_fee, required: true, type: "number", min:"0" %>
+      </div>
+      <div class="form_box">
+        <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :student_fee %>
         <%= f.text_field :student_fee, required: true, type: "number", min:"0" %>
+      </div>
+      <div class="form_box">
+        <i class="fas fa-caret-square-right text-blue-600"></i>
+        <%= f.label :extension_student_fee %>
+        <%= f.text_field :extension_student_fee, required: true, type: "number", min:"0" %>
       </div>
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
@@ -30,9 +42,20 @@
       </div>
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
+        <%= f.label :extension_senior_fee %>
+        <%= f.text_field :extension_senior_fee, required: true, type: "number", min:"0" %>
+      </div>
+      <div class="form_box">
+        <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :child_fee %>
         <%= f.text_field :child_fee, required: true, type: "number", min:"0" %>
       </div>
+      <div class="form_box">
+        <i class="fas fa-caret-square-right text-blue-600"></i>
+        <%= f.label :extension_child_fee %>
+        <%= f.text_field :extension_child_fee, required: true, type: "number", min:"0" %>
+      </div>
+
     </div>
     <div id="l_note">
       <div>

--- a/app/views/drink_plans/index.html.erb
+++ b/app/views/drink_plans/index.html.erb
@@ -25,7 +25,7 @@
         <%= f.select :fee_type_eq, DrinkPlan.fee_types.map{|k, v| [DrinkPlan.fee_types_i18n[k], v]}, include_blank: true %>
       </div>
       <div>
-        <%= f.label :base_time_eq, "単位:" %>
+        <%= f.label :base_time_eq, "基本時間:" %>
         <%= f.select :base_time_eq, DrinkPlan.base_times.map{|k, v| [DrinkPlan.base_times_i18n[k], v]}, include_blank: true %>
       </div>
       <div id="index_search_btn">
@@ -33,29 +33,29 @@
       </div>
       <% end %>
     </div>
-    <div class="max-w-screen-lg border border-gray-400 bg-white rounded-lg shadow overflow-x-auto overflow-y-auto mx-5 my-6 lg:mx-auto items-center">
+    <div class="w-11/12 max-w-screen-lg border border-gray-400 bg-white rounded-lg shadow overflow-x-auto overflow-y-auto mx-5 my-6 lg:mx-auto items-center">
       <table class="border-collapse table-auto w-full whitespace-no-wrap bg-white table-striped">
           <tr id="table_heading" class="bg-blue-500">
-            <th class="index_table_head  hidden md:table-cell">No.</th>
+            <th class="index_table_head  hidden lg:table-cell">No.</th>
             <th class="index_table_head">料金種類</th>
             <th class="index_table_head">基本時間</th>
-            <th class="index_table_head hidden md:table-cell">一般</th>
-            <th class="index_table_head hidden md:table-cell">学生</th>
-            <th class="index_table_head hidden md:table-cell">シニア</th>
-            <th class="index_table_head hidden md:table-cell">小学生</th>
+            <th class="index_table_head hidden lg:table-cell">一般</th>
+            <th class="index_table_head hidden lg:table-cell">学生</th>
+            <th class="index_table_head hidden lg:table-cell">シニア</th>
+            <th class="index_table_head hidden lg:table-cell">小学生</th>
             <th class="index_table_head" colspan="2"><i class="fas fa-edit text-white"></th>
           </tr>
         </thead>
         <tbody>
           <% @drink_plans.each.with_index(1) do |drink_plan, i| %>
             <tr class="border-b border-gray-200 hover:bg-gray-100">
-              <td class="index_table_body hidden md:table-cell"><%= i %></td>
-              <td class="border border-gray-400 px-2 py-1 text-center text-blue-600 text-sm"><%= link_to drink_plan.fee_type_i18n, drink_plan %></td>
+              <td class="index_table_body hidden lg:table-cell"><%= i %></td>
+              <td class="border border-gray-400 px-1 py-1 text-center text-blue-600 text-xs xl:text-sm"><%= link_to drink_plan.fee_type_i18n, drink_plan %></td>
               <td class="index_table_body"><%= drink_plan.base_time_i18n %></td>
-              <td class="index_table_body hidden md:table-cell"><%= drink_plan.adult_fee.to_s(:delimited, delimiter: ',') %>円</td>
-              <td class="index_table_body hidden md:table-cell"><%= drink_plan.student_fee.to_s(:delimited, delimiter: ',') %>円</td>
-              <td class="index_table_body hidden md:table-cell"><%= drink_plan.senior_fee.to_s(:delimited, delimiter: ',') %>円</td>
-              <td class="index_table_body hidden md:table-cell"><%= drink_plan.child_fee.to_s(:delimited, delimiter: ',') %>円</td>
+              <td class="index_table_body hidden lg:table-cell"><%= drink_plan.adult_fee.to_s(:delimited, delimiter: ',') %>円</td>
+              <td class="index_table_body hidden lg:table-cell"><%= drink_plan.student_fee.to_s(:delimited, delimiter: ',') %>円</td>
+              <td class="index_table_body hidden lg:table-cell"><%= drink_plan.senior_fee.to_s(:delimited, delimiter: ',') %>円</td>
+              <td class="index_table_body hidden lg:table-cell"><%= drink_plan.child_fee.to_s(:delimited, delimiter: ',') %>円</td>
               <td class="index_table_body sm:text-sm text-green-600"><%= link_to "編集", edit_drink_plan_path(drink_plan) %></td>
               <td class="index_table_body sm:text-sm text-red-600"><%= link_to "削除", drink_plan, method: :delete, data: { confirm: "このプランを削除しますか?" } %></td>
             </tr>

--- a/app/views/drink_plans/index.html.erb
+++ b/app/views/drink_plans/index.html.erb
@@ -21,12 +21,12 @@
     <div id="d_search_box"  class="hidden md:flex">
       <%= search_form_for @q do |f| %>
       <div>
-        <%= f.label :name_cont, "料金名称:", class: 'first_label'%>
-        <%= f.search_field :name_cont %>
+        <%= f.label :fee_type_eq, "料金種類:" %>
+        <%= f.select :fee_type_eq, DrinkPlan.fee_types.map{|k, v| [DrinkPlan.fee_types_i18n[k], v]}, include_blank: true %>
       </div>
       <div>
-        <%= f.label :time_unit_eq, "単位:" %>
-        <%= f.select :time_unit_eq, DrinkPlan.time_units.map{|k, v| [DrinkPlan.time_units_i18n[k], v]}, include_blank: true %>
+        <%= f.label :base_time_eq, "単位:" %>
+        <%= f.select :base_time_eq, DrinkPlan.base_times.map{|k, v| [DrinkPlan.base_times_i18n[k], v]}, include_blank: true %>
       </div>
       <div id="index_search_btn">
         <%= f.submit "検索", class: "btn_search"  %>
@@ -37,8 +37,8 @@
       <table class="border-collapse table-auto w-full whitespace-no-wrap bg-white table-striped">
           <tr id="table_heading" class="bg-blue-500">
             <th class="index_table_head  hidden md:table-cell">No.</th>
-            <th class="index_table_head">料金名称</th>
-            <th class="index_table_head">単位</th>
+            <th class="index_table_head">料金種類</th>
+            <th class="index_table_head">基本時間</th>
             <th class="index_table_head hidden md:table-cell">一般</th>
             <th class="index_table_head hidden md:table-cell">学生</th>
             <th class="index_table_head hidden md:table-cell">シニア</th>
@@ -50,8 +50,8 @@
           <% @drink_plans.each.with_index(1) do |drink_plan, i| %>
             <tr class="border-b border-gray-200 hover:bg-gray-100">
               <td class="index_table_body hidden md:table-cell"><%= i %></td>
-              <td class="border border-gray-400 px-2 py-1 text-center text-blue-600 text-sm"><%= link_to drink_plan.name, drink_plan %></td>
-              <td class="index_table_body"><%= drink_plan.time_unit_i18n %></td>
+              <td class="border border-gray-400 px-2 py-1 text-center text-blue-600 text-sm"><%= link_to drink_plan.fee_type_i18n, drink_plan %></td>
+              <td class="index_table_body"><%= drink_plan.base_time_i18n %></td>
               <td class="index_table_body hidden md:table-cell"><%= drink_plan.adult_fee.to_s(:delimited, delimiter: ',') %>円</td>
               <td class="index_table_body hidden md:table-cell"><%= drink_plan.student_fee.to_s(:delimited, delimiter: ',') %>円</td>
               <td class="index_table_body hidden md:table-cell"><%= drink_plan.senior_fee.to_s(:delimited, delimiter: ',') %>円</td>

--- a/app/views/drink_plans/show.html.erb
+++ b/app/views/drink_plans/show.html.erb
@@ -20,35 +20,46 @@
     <h1 class="page_title">ドリンクコース料金詳細</h1>
     <div id="show_wrapper">
       <div id="plan_title">
-        <p class="bg-yellow-300 px-2 py-2 border-2 border-gray-500 rounded-md"><%= @drink_plan.name %></p>
+        <p class="bg-yellow-300 px-2 py-2 border-2 border-gray-500 rounded-md"><%= @drink_plan.fee_type_i18n %></p>
       </div>
       <table class="table-auto border-collapse border-2 border-gray-500" id="d_plan_div_table">
         <thead>
           <tr id="table_heading" class="bg-blue-500 text-center text-sm font-bold">
-            <th class="show_div_table_head">単位</th>
+            <th class="show_div_table_head">基本時間</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td class="show_div_table_body" style="width: 60px"><%= @drink_plan.time_unit_i18n %></td>
+            <td class="show_div_table_body" style="width: 60px"><%= @drink_plan.base_time_i18n %></td>
           </tr>
         </tbody>
       </table>
       <table class="table-auto border-collapse border-2 border-gray-500 w-full" id="plan_fee_table" id="plan_fee_table">
         <thead>
           <tr id="table_heading" class="bg-blue-500 text-center text-sm font-bold">
-            <th class="show_fee_table_head w-1/4">一般料金</th>
-            <th class="show_fee_table_head w-1/4">学生料金</th>
-            <th class="show_fee_table_head w-1/4">シニア料金</th>
-            <th class="show_fee_table_head w-1/4">小学生料金</th>
+            <th class="show_fee_table_head w-1/5"></th>
+            <th class="show_fee_table_head w-1/5">一般料金</th>
+            <th class="show_fee_table_head w-1/5">学生料金</th>
+            <th class="show_fee_table_head w-1/5">シニア料金</th>
+            <th class="show_fee_table_head w-1/5">小学生料金</th>
           </tr>
         </thead>
         <tbody>
           <tr>
+            <td class="show_fee_table_body">基本料金</td>
             <td class="show_fee_table_body"><%= @drink_plan.adult_fee.to_s(:delimited, delimiter: ',') %>円</td>
             <td class="show_fee_table_body"><%= @drink_plan.student_fee.to_s(:delimited, delimiter: ',') %>円</td>
             <td class="show_fee_table_body"><%= @drink_plan.senior_fee.to_s(:delimited, delimiter: ',') %>円</td>
             <td class="show_fee_table_body"><%= @drink_plan.child_fee.to_s(:delimited, delimiter: ',') %>円</td>
+          </tr>
+        </tbody>
+        <tbody>
+          <tr>
+            <td class="show_fee_table_body">延長料金</td>
+            <td class="show_fee_table_body"><%= @drink_plan.extension_adult_fee.to_s(:delimited, delimiter: ',') %>円</td>
+            <td class="show_fee_table_body"><%= @drink_plan.extension_student_fee.to_s(:delimited, delimiter: ',') %>円</td>
+            <td class="show_fee_table_body"><%= @drink_plan.extension_senior_fee.to_s(:delimited, delimiter: ',') %>円</td>
+            <td class="show_fee_table_body"><%= @drink_plan.extension_child_fee.to_s(:delimited, delimiter: ',') %>円</td>
           </tr>
         </tbody>
       </table>

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -26,6 +26,11 @@ ja:
         base_one_hour: '60分'
         base_one_half_hour: '90分'
         base_free_time: 'フリー'
+      fee_type:
+        drink_bar: 'ドリンクバー料金'
+        lite_plan: 'ライト飲み放題料金'
+        variety_plan: 'バラエティ飲み放題料金'
+        deluxe_plan: 'デラックス飲み放題料金'
     fee_guide:
       div_member:
         other: '一般'

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -21,6 +21,11 @@ ja:
       time_unit:
         half_hour: '30分'
         free_time: 'フリー'
+      base_time:
+        half_hour: '30分'
+        one_hour: '60分'
+        one_half_hour: '90分'
+        free_time: 'フリー'
     fee_guide:
       div_member:
         other: '一般'

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -22,10 +22,10 @@ ja:
         half_hour: '30分'
         free_time: 'フリー'
       base_time:
-        half_hour: '30分'
-        one_hour: '60分'
-        one_half_hour: '90分'
-        free_time: 'フリー'
+        base_half_hour: '30分'
+        base_one_hour: '60分'
+        base_one_half_hour: '90分'
+        base_free_time: 'フリー'
     fee_guide:
       div_member:
         other: '一般'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -25,6 +25,11 @@ ja:
         student_fee: 学生料金
         senior_fee: シニア料金
         child_fee: 小学生料金
+        base_time: 基本時間
+        extension_adult_fee: 一般延長料金
+        extension_student_fee: 学生延長料金
+        extension_senior_fee: シニア延長料金
+        extension_child_fee: 小学生延長料金
       fee_guide:
         div_member: 会員区分
         number_of_adults: 一般人数

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,15 +21,16 @@ ja:
         name: 料金名
         note: 備考
         time_unit: 時間単位
-        adult_fee: 一般料金
-        student_fee: 学生料金
-        senior_fee: シニア料金
-        child_fee: 小学生料金
+        adult_fee: 一般料金/基本
+        student_fee: 学生料金/基本
+        senior_fee: シニア料金/基本
+        child_fee: 小学生料金/基本
         base_time: 基本時間
-        extension_adult_fee: 一般延長料金
-        extension_student_fee: 学生延長料金
-        extension_senior_fee: シニア延長料金
-        extension_child_fee: 小学生延長料金
+        extension_adult_fee: 一般料金/延長
+        extension_student_fee: 学生料金/延長
+        extension_senior_fee: シニア料金/延長
+        extension_child_fee: 小学生料金/延長
+        fee_type: 料金種類
       fee_guide:
         div_member: 会員区分
         number_of_adults: 一般人数

--- a/db/migrate/20210926020732_add_colmuns_to_drink_plans.rb
+++ b/db/migrate/20210926020732_add_colmuns_to_drink_plans.rb
@@ -1,0 +1,11 @@
+class AddColmunsToDrinkPlans < ActiveRecord::Migration[6.1]
+  def change
+    change_table :drink_plans, bulk: true do |t|
+      t.integer :base_time, null: false, default: 0
+      t.integer :extension_adult_fee, null: false
+      t.integer :extension_student_fee, null: false
+      t.integer :extension_senior_fee, null: false
+      t.integer :extension_child_fee, null: false
+    end
+  end
+end

--- a/db/migrate/20210926072555_add_fee_type_to_drink_plans.rb
+++ b/db/migrate/20210926072555_add_fee_type_to_drink_plans.rb
@@ -1,0 +1,7 @@
+class AddFeeTypeToDrinkPlans < ActiveRecord::Migration[6.1]
+  def change
+    change_table :drink_plans, bulk: true do |t|
+      t.integer :fee_type, null: false, default: 0
+    end
+  end
+end

--- a/db/migrate/20210926081008_remove_colmuns_from_drink_plans.rb
+++ b/db/migrate/20210926081008_remove_colmuns_from_drink_plans.rb
@@ -1,0 +1,15 @@
+class RemoveColmunsFromDrinkPlans < ActiveRecord::Migration[6.1]
+  def up
+    change_table :drink_plans, bulk: true do |t|
+      t.remove :name
+      t.remove :time_unit
+    end
+  end
+
+  def down
+    change_table :drink_plans, bulk: true do |t|
+      t.string :name
+      t.integer :time_unit
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_16_144014) do
+ActiveRecord::Schema.define(version: 2021_09_26_020732) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,11 @@ ActiveRecord::Schema.define(version: 2021_09_16_144014) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "shop_id"
+    t.integer "base_time", default: 0, null: false
+    t.integer "extension_adult_fee", null: false
+    t.integer "extension_student_fee", null: false
+    t.integer "extension_senior_fee", null: false
+    t.integer "extension_child_fee", null: false
     t.index ["shop_id"], name: "index_drink_plans_on_shop_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_26_020732) do
+ActiveRecord::Schema.define(version: 2021_09_26_081008) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "drink_plans", force: :cascade do |t|
-    t.string "name", null: false
     t.text "note"
-    t.integer "time_unit", default: 0, null: false
     t.integer "adult_fee", null: false
     t.integer "student_fee", null: false
     t.integer "senior_fee", null: false
@@ -31,6 +29,7 @@ ActiveRecord::Schema.define(version: 2021_09_26_020732) do
     t.integer "extension_student_fee", null: false
     t.integer "extension_senior_fee", null: false
     t.integer "extension_child_fee", null: false
+    t.integer "fee_type", default: 0, null: false
     t.index ["shop_id"], name: "index_drink_plans_on_shop_id"
   end
 

--- a/test/controllers/static_pages_controller_test 2.rb
+++ b/test/controllers/static_pages_controller_test 2.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class StaticPagesControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 実装内容
- `fee_type`(料金種類)と`base_time`(基本時間)のカラムを追加
  -  共に`NOTNULL`制約 
  -  enum型とし、それぞれの設定と日本語化を記述
- `name`カラムと`time_unit`カラムを削除
- 上記に伴う、料金案内の計算方法を変更。`fee_guide.rb`に記述。

※ 料金案内時に料金名から該当料金を検索する形では、該当しないエラーが発生しやすいため、enum型からselectboxで選ぶ形とした。

### 確認事項
- ローカル環境で動作を確認
- `rubocop -a`を実行