### PR TITLE
MainPlanモデルのDB設計の見直し

### DIFF
--- a/app/controllers/fee_guides_controller.rb
+++ b/app/controllers/fee_guides_controller.rb
@@ -15,7 +15,7 @@ class FeeGuidesController < ApplicationController
 
   def create
     @fee_guide = FeeGuide.new(fee_guide_params)
-    @fee_guide.set_values
+    @fee_guide.set_calculated_result
     if @fee_guide.save!
       redirect_to edit_fee_guide_url(@fee_guide)
     else

--- a/app/controllers/main_plans_controller.rb
+++ b/app/controllers/main_plans_controller.rb
@@ -50,7 +50,7 @@ class MainPlansController < ApplicationController
   end
 
   def main_plan_params
-    params.require(:main_plan).permit(:name, :note, :div_member, :div_day, :div_time, :time_unit, :adult_fee,
+    params.require(:main_plan).permit(:fee_type, :note, :div_member, :div_day, :div_time, :time_unit, :adult_fee,
                                       :student_fee, :senior_fee, :child_fee)
   end
 end

--- a/app/controllers/static_pages_controller 2.rb
+++ b/app/controllers/static_pages_controller 2.rb
@@ -1,7 +1,0 @@
-class StaticPagesController < ApplicationController
-  def home; end
-
-  def coupon; end
-
-  def alcohol_plan; end
-end

--- a/app/helpers/static_pages_helper 2.rb
+++ b/app/helpers/static_pages_helper 2.rb
@@ -1,2 +1,0 @@
-module StaticPagesHelper
-end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -731,14 +731,16 @@ p {
 
 // 登録フォーム
 #form_wrap {
-  width: 80%;
-  max-width: 680px;
+  width: 95%;
+  max-width: 750px;
   margin: 0 auto;
   margin-top: 20px;
   @include mq-down(md) {
     margin-top: 20px;
   }
-  #l_name,
+  @include mq-down(sm) {
+    width: 90%;
+  }
   #l_note {
     margin-bottom: 20px;
     i {
@@ -767,16 +769,14 @@ p {
   }
   #l_div,
   #l_fee {
-    display: flex;
-    flex-wrap: wrap;
-    .form_box {
-      margin-right: 40px;
+    .form_box,
+    .form_box_fee_type {
       margin-bottom: 20px;
       label {
         font-size: 14px;
         margin-right: 10px;
         display: inline-block;
-        width: 100px;
+        width: 90px;
         text-align: justify;
         text-align-last: justify;
       }
@@ -785,12 +785,17 @@ p {
         padding: 5px 10px 5px 10px;
         border: gray 1px solid;
         border-radius: 5px;
-        width: 100px;
+        width: 80px;
         font-size: 12px;
         background: white;
       }
       select {
         padding-left: 5px;
+      }
+    }
+    .form_box_fee_type {
+      select {
+        width: 140px;
       }
     }
   }

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -732,7 +732,7 @@ p {
 // 登録フォーム
 #form_wrap {
   width: 80%;
-  max-width: 630px;
+  max-width: 680px;
   margin: 0 auto;
   margin-top: 20px;
   @include mq-down(md) {
@@ -792,12 +792,40 @@ p {
       select {
         padding-left: 5px;
       }
+    }
+  }
+  #l_div_drink,
+  #l_fee_drink {
+    display: flex;
+    flex-wrap: wrap;
+    .form_box {
+      margin-right: 40px;
+      margin-bottom: 20px;
+      label {
+        font-size: 14px;
+        margin-right: 10px;
+        display: inline-block;
+        width: 120px;
+        text-align: justify;
+        text-align-last: justify;
+      }
+      select,
+      input {
+        padding: 5px 10px 5px 10px;
+        border: gray 1px solid;
+        border-radius: 5px;
+        width: 100px;
+        font-size: 12px;
+        background: white;
+      }
+      select {
+        padding-left: 5px;
+      }
       #drink_plan_fee_type {
-        width: 150px;
+        width: 200px;
       }
     }
   }
-
   #l_note {
     display: block;
     div {

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -633,25 +633,56 @@ p {
   margin-top: 30px;
   width: 100%;
   font-size: 14px;
-  .main_plan_search {
+  .main_plan_search,
+  .drink_plan_search {
     display: flex;
     justify-content: center;
     align-items: flex-end;
     width: 100%;
-    label {
-      margin-left: 15px;
-      margin-right: 5px;
-      margin-bottom: 0;
+    #fee_type_search,
+    #fee_type_search_d {
+      label {
+        margin-right: 5px;
+        margin-bottom: 0;
+      }
+      select {
+        width: 150px;
+        height: 30px;
+        font-size: 14px;
+        border: gray 1px solid;
+        border-radius: 5px;
+        background: white;
+        cursor: pointer;
+        padding-left: 5px;
+      }
     }
-    .first_label {
-      margin-left: 0;
+    #other_search,
+    #other_search_d {
+      label {
+        margin-left: 15px;
+        margin-right: 5px;
+        margin-bottom: 0;
+      }
+      select {
+        width: 80px;
+        height: 30px;
+        font-size: 14px;
+        border: gray 1px solid;
+        border-radius: 5px;
+        background: white;
+        cursor: pointer;
+        padding-left: 5px;
+      }
     }
-    input,
-    select {
-      border: gray 1px solid;
-      border-radius: 5px;
-      background: white;
-      cursor: pointer;
+    #fee_type_search_d {
+      select {
+        width: 200px;
+      }
+    }
+    #other_search_d {
+      select {
+        width: 120px;
+      }
     }
   }
   #index_search_btn {
@@ -732,7 +763,7 @@ p {
 // 登録フォーム
 #form_wrap {
   width: 95%;
-  max-width: 750px;
+  max-width: 650px;
   margin: 0 auto;
   margin-top: 20px;
   @include mq-down(md) {
@@ -741,42 +772,16 @@ p {
   @include mq-down(sm) {
     width: 90%;
   }
-  #l_note {
-    margin-bottom: 20px;
-    i {
-      font-size: 14px;
-      margin-top: 9px;
-      vertical-align: top;
-    }
-    label {
-      margin-top: 5px;
-      margin-right: 10px;
-      display: inline-block;
-      width: 80px;
-      text-align: justify;
-      text-align-last: justify;
-      vertical-align: top;
-      font-size: 14px;
-    }
-    input {
-      width: 100%;
-      padding: 5px;
-      border: gray 1px solid;
-      border-radius: 5px;
-      font-size: 12px;
-      background: white;
-    }
-  }
   #l_div,
   #l_fee {
     .form_box,
-    .form_box_fee_type {
+    .form_box_long {
       margin-bottom: 20px;
       label {
         font-size: 14px;
         margin-right: 10px;
         display: inline-block;
-        width: 90px;
+        width: 110px;
         text-align: justify;
         text-align-last: justify;
       }
@@ -786,64 +791,47 @@ p {
         border: gray 1px solid;
         border-radius: 5px;
         width: 80px;
-        font-size: 12px;
-        background: white;
-      }
-      select {
-        padding-left: 5px;
-      }
-    }
-    .form_box_fee_type {
-      select {
-        width: 140px;
-      }
-    }
-  }
-  #l_div_drink,
-  #l_fee_drink {
-    display: flex;
-    flex-wrap: wrap;
-    .form_box {
-      margin-right: 40px;
-      margin-bottom: 20px;
-      label {
         font-size: 14px;
-        margin-right: 10px;
-        display: inline-block;
-        width: 120px;
-        text-align: justify;
-        text-align-last: justify;
-      }
-      select,
-      input {
-        padding: 5px 10px 5px 10px;
-        border: gray 1px solid;
-        border-radius: 5px;
-        width: 100px;
-        font-size: 12px;
         background: white;
+        @include mq-down(sm) {
+          width: 150px;
+        }
       }
       select {
         padding-left: 5px;
       }
-      #drink_plan_fee_type {
-        width: 200px;
+    }
+    .form_box_long {
+      select {
+        width: 150px;
       }
     }
   }
   #l_note {
-    display: block;
-    div {
-      textarea {
-        margin-top: 5px;
-        width: 100%;
-        min-height: 100px;
-        padding: 8px;
-        font-size: 10px;
-        border: gray 1px solid;
-        border-radius: 5px;
-        white-space: normal;
-      }
+    margin-bottom: 20px;
+    i {
+      font-size: 16px;
+      margin-top: 9px;
+      vertical-align: top;
+    }
+    label {
+      margin-top: 5px;
+      margin-right: 10px;
+      display: inline-block;
+      width: 110px;
+      text-align: justify;
+      text-align-last: justify;
+      vertical-align: top;
+      font-size: 14px;
+    }
+    textarea {
+      width: 100%;
+      height: 120px;
+      padding: 5px;
+      border: gray 1px solid;
+      border-radius: 5px;
+      font-size: 14px;
+      background: white;
     }
   }
 }
@@ -868,7 +856,6 @@ p {
     .first_label {
       margin-left: 0;
     }
-    input,
     select {
       border: gray 1px solid;
       border-radius: 5px;

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -97,13 +97,13 @@ class FeeGuide < ApplicationRecord
   # それぞれのルーム料金を計算
   def set_main_fee_free_time
     wday = get_business_wday
-    time = if usage_time == "three_hour"
-             get_div_time_three_hour
-             chosen_free_plan = get_three_hour_plan(wday, time)
-           else
-             get_div_time_free_time
-             chosen_free_plan = get_free_plan(wday, time)
-           end
+    if usage_time == "three_hour"
+      time = get_div_time_three_hour
+      chosen_free_plan = get_three_hour_plan(wday, time)
+    else
+      time = get_div_time_free_time
+      chosen_free_plan = get_free_plan(wday, time)
+    end
     self.adult_main_fee = chosen_free_plan.adult_fee
     self.student_main_fee = chosen_free_plan.student_fee
     self.senior_main_fee = chosen_free_plan.senior_fee
@@ -225,13 +225,13 @@ class FeeGuide < ApplicationRecord
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: 0, fee_type: 0)
   end
 
-  # フォームで取得した内容から該当の「夜30分料金を取得」
+  # フォームで取得した内容か���該当の「夜30分料金を取得」
   def get_night_plan(wday)
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: 1, fee_type: 0)
   end
 
   # フォームで取得した内容から該当の「3時間パック料金を取得」
-  def get_free_plan(wday, time)
+  def get_three_hour_plan(wday, time)
     MainPlan.find_by(div_member: div_member, div_day: wday, div_time: time, fee_type: 1)
   end
 

--- a/app/models/main_plan.rb
+++ b/app/models/main_plan.rb
@@ -5,7 +5,6 @@ class MainPlan < ApplicationRecord
     validates :div_member
     validates :div_day
     validates :div_time
-    validates :time_unit
     with_options numericality: { only_integer: true, greater_than_or_equal_to: 0 } do
       validates :adult_fee
       validates :student_fee
@@ -16,9 +15,9 @@ class MainPlan < ApplicationRecord
   validates :note, length: { maximum: 250 }
 
   enum fee_type: {
-    half_hour_fee: 0,
-    three_hour_fee: 1
-    free_time_fee: 1
+    half_hour: 0,
+    three_hour: 1,
+    free_time: 2
   }
 
   enum div_member: {
@@ -36,11 +35,5 @@ class MainPlan < ApplicationRecord
     day: 0,
     night: 1,
     evening: 2
-  }
-
-  enum time_unit: {
-    half_hour: 0,
-    three_hour: 1,
-    free_time: 2
   }
 end

--- a/app/models/main_plan.rb
+++ b/app/models/main_plan.rb
@@ -15,6 +15,12 @@ class MainPlan < ApplicationRecord
   end
   validates :note, length: { maximum: 250 }
 
+  enum fee_type: {
+    half_hour_fee: 0,
+    three_hour_fee: 1
+    free_time_fee: 1
+  }
+
   enum div_member: {
     other: 0,
     member: 1

--- a/app/models/main_plan.rb
+++ b/app/models/main_plan.rb
@@ -1,7 +1,7 @@
 class MainPlan < ApplicationRecord
   belongs_to :shop
   with_options presence: true do
-    validates :name
+    validates :fee_type
     validates :div_member
     validates :div_day
     validates :div_time

--- a/app/views/drink_plans/_form_drink_plans.html.erb
+++ b/app/views/drink_plans/_form_drink_plans.html.erb
@@ -1,20 +1,20 @@
 <div class="sm:border-2 rounded-lg sm:shadow my-4 p-1 sm:p-8" id="form_wrap">
   <%= form_with model: @drink_plan, local: true do |f| %>
-    <div id="l_div_drink">
-      <div class="form_box">
+    <div id="l_div">
+      <div class="form_box_long">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :fee_type %>
         <%= f.select :fee_type, DrinkPlan.fee_types_i18n.invert %>
       </div>
     </div>
-    <div id="l_div_drink">
-      <div class="form_box">
+    <div id="l_div">
+      <div class="form_box_long">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :base_time %>
         <%= f.select :base_time, DrinkPlan.base_times_i18n.invert %>
       </div>
     </div>
-    <div id="l_fee_drink">
+    <div class="grid grid-cols-1 sm:grid-cols-2" id="l_fee">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :adult_fee %>
@@ -55,7 +55,6 @@
         <%= f.label :extension_child_fee %>
         <%= f.text_field :extension_child_fee, required: true, type: "number", min:"0" %>
       </div>
-
     </div>
     <div id="l_note">
       <div>

--- a/app/views/drink_plans/_form_drink_plans.html.erb
+++ b/app/views/drink_plans/_form_drink_plans.html.erb
@@ -1,20 +1,20 @@
 <div class="sm:border-2 rounded-lg sm:shadow my-4 p-1 sm:p-8" id="form_wrap">
   <%= form_with model: @drink_plan, local: true do |f| %>
-    <div id="l_div">
+    <div id="l_div_drink">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :fee_type %>
         <%= f.select :fee_type, DrinkPlan.fee_types_i18n.invert %>
       </div>
     </div>
-    <div id="l_div">
+    <div id="l_div_drink">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :base_time %>
         <%= f.select :base_time, DrinkPlan.base_times_i18n.invert %>
       </div>
     </div>
-    <div id="l_fee">
+    <div id="l_fee_drink">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :adult_fee %>

--- a/app/views/drink_plans/index.html.erb
+++ b/app/views/drink_plans/index.html.erb
@@ -18,13 +18,13 @@
   </div>
   <div id="main_contents_shop">
     <h1 class="page_title">ドリンク料金一覧</h1>
-    <div id="d_search_box"  class="hidden md:flex">
+    <div id="m_search_box"  class="hidden md:flex">
       <%= search_form_for @q do |f| %>
-      <div>
-        <%= f.label :fee_type_eq, "料金種類:" %>
+      <div id="fee_type_search_d">
+        <%= f.label :fee_type_eq, "料金名:" %>
         <%= f.select :fee_type_eq, DrinkPlan.fee_types.map{|k, v| [DrinkPlan.fee_types_i18n[k], v]}, include_blank: true %>
       </div>
-      <div>
+      <div id="other_search_d">
         <%= f.label :base_time_eq, "基本時間:" %>
         <%= f.select :base_time_eq, DrinkPlan.base_times.map{|k, v| [DrinkPlan.base_times_i18n[k], v]}, include_blank: true %>
       </div>

--- a/app/views/main_plans/_form_main_plans.html.erb
+++ b/app/views/main_plans/_form_main_plans.html.erb
@@ -1,13 +1,13 @@
 <div class="sm:border-2 rounded-lg sm:shadow my-6 p-1 sm:p-8" id="form_wrap">
   <%= form_with model: @main_plan, local: true do |f| %>
     <div class="w-full" id="l_div">
-      <div class="form_box_fee_type">
+      <div class="form_box_long">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :fee_type %>
         <%= f.select :fee_type, MainPlan.fee_types_i18n.invert%>
       </div>
     </div>
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" id="l_div">
+    <div class="grid grid-cols-1 sm:grid-cols-2" id="l_div">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :div_day %>
@@ -17,11 +17,6 @@
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :div_time %>
         <%= f.select :div_time, MainPlan.div_times_i18n.invert %>
-      </div>
-      <div class="form_box">
-        <i class="fas fa-caret-square-right text-blue-600"></i>
-        <%= f.label :time_unit %>
-        <%= f.select :time_unit, MainPlan.time_units_i18n.invert, class: "time_unit_select" %>
       </div>
     </div>
     <div id="l_div">

--- a/app/views/main_plans/_form_main_plans.html.erb
+++ b/app/views/main_plans/_form_main_plans.html.erb
@@ -1,16 +1,13 @@
 <div class="sm:border-2 rounded-lg sm:shadow my-6 p-1 sm:p-8" id="form_wrap">
   <%= form_with model: @main_plan, local: true do |f| %>
-    <div id="l_name">
-      <i class="fas fa-caret-square-right text-blue-600"></i>
-      <%= f.label :name %>
-      <%= f.text_field :name, required: true %>
-    </div>
-    <div id="l_div">
-      <div class="form_box">
+    <div class="w-full" id="l_div">
+      <div class="form_box_fee_type">
         <i class="fas fa-caret-square-right text-blue-600"></i>
-        <%= f.label :div_member %>
-        <%= f.select :div_member, MainPlan.div_members_i18n.invert %>
+        <%= f.label :fee_type %>
+        <%= f.select :fee_type, MainPlan.fee_types_i18n.invert%>
       </div>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3" id="l_div">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :div_day %>
@@ -27,7 +24,14 @@
         <%= f.select :time_unit, MainPlan.time_units_i18n.invert, class: "time_unit_select" %>
       </div>
     </div>
-    <div id="l_fee">
+    <div id="l_div">
+      <div class="form_box">
+        <i class="fas fa-caret-square-right text-blue-600"></i>
+        <%= f.label :div_member %>
+        <%= f.select :div_member, MainPlan.div_members_i18n.invert %>
+      </div>
+    </div>
+    <div class="grid grid-cols-1 sm:grid-cols-2" id="l_fee">
       <div class="form_box">
         <i class="fas fa-caret-square-right text-blue-600"></i>
         <%= f.label :adult_fee %>

--- a/app/views/main_plans/index.html.erb
+++ b/app/views/main_plans/index.html.erb
@@ -20,25 +20,21 @@
     <h1 class="page_title">ルーム料金一覧</h1>
     <div id="m_search_box" class="hidden md:flex">
       <%= search_form_for @q do |f| %>
-        <div>
-          <%= f.label :name_cont, "料金名称:", class: 'first_label'%>
-          <%= f.search_field :name_cont %>
+        <div class="hidden lg:block" id="fee_type_search">
+          <%= f.label :fee_type_eq, "料金名:" %>
+          <%= f.select :fee_type_eq, MainPlan.fee_types.map{|k, v| [MainPlan.fee_types_i18n[k], v]}, include_blank: true %>
         </div>
-        <div class="hidden lg:block">
-          <%= f.label :div_member_eq, "区分:" %>
-          <%= f.select :div_member_eq, MainPlan.div_members.map{|k, v| [MainPlan.div_members_i18n[k], v]}, include_blank: true %>
-        </div>
-        <div>
+        <div id="other_search">
           <%= f.label :div_day_eq, "曜日:" %>
           <%= f.select :div_day_eq, MainPlan.div_days.map{|k, v| [MainPlan.div_days_i18n[k], v]}, include_blank: true %>
-        </div class="hidden lg:block">
-        <div>
+        </div>
+        <div id="other_search">
           <%= f.label :div_time_eq, "時間帯:" %>
           <%= f.select :div_time_eq, MainPlan.div_times.map{|k, v| [MainPlan.div_times_i18n[k], v]}, include_blank: true %>
         </div>
-        <div class="hidden lg:block">
-          <%= f.label :time_unit_eq, "単位:" %>
-          <%= f.select :time_unit_eq, MainPlan.time_units.map{|k, v| [MainPlan.time_units_i18n[k], v]}, include_blank: true %>
+        <div id="other_search">
+          <%= f.label :div_member_eq, "会員:" %>
+          <%= f.select :div_member_eq, MainPlan.div_members.map{|k, v| [MainPlan.div_members_i18n[k], v]}, include_blank: true %>
         </div>
         <div id="index_search_btn">
           <%= f.submit "検索", class: "btn_search"  %>
@@ -50,11 +46,10 @@
         <thead>
           <tr id="table_heading" class="bg-blue-500 sticky top-0">
             <th class="index_table_head hidden xl:table-cell">No.</th>
-            <th class="index_table_head">料金名称</th>
-            <th class="index_table_head">区分</th>
+            <th class="index_table_head">料金名</th>
             <th class="index_table_head">曜日</th>
             <th class="index_table_head">時間</th>
-            <th class="index_table_head hidden lg:table-cell">単位</th>
+            <th class="index_table_head">会員</th>
             <th class="index_table_head hidden lg:table-cell">一般</th>
             <th class="index_table_head hidden lg:table-cell">学生</th>
             <th class="index_table_head hidden lg:table-cell">シニア</th>
@@ -66,11 +61,10 @@
           <% @main_plans.each.with_index(1) do |main_plan, i| %>
             <tr class="border-b border-gray-200 hover:bg-gray-100">
               <td class="index_table_body hidden xl:table-cell"><%= i %></td>
-              <td class="index_table_body text-blue-600"><%= link_to main_plan.name, main_plan %></td>
-              <td class="index_table_body"><%= main_plan.div_member_i18n %></td>
+              <td class="index_table_body text-blue-600"><%= link_to main_plan.fee_type_i18n, main_plan %></td>
               <td class="index_table_body"><%= main_plan.div_day_i18n %></td>
               <td class="index_table_body"><%= main_plan.div_time_i18n %></td>
-              <td class="index_table_body hidden lg:table-cell"><%= main_plan.time_unit_i18n %></td>
+              <td class="index_table_body"><%= main_plan.div_member_i18n %></td>
               <td class="index_table_body hidden lg:table-cell"><%= main_plan.adult_fee.to_s(:delimited, delimiter: ',') %>円</td>
               <td class="index_table_body hidden lg:table-cell"><%= main_plan.student_fee.to_s(:delimited, delimiter: ',') %>円</td>
               <td class="index_table_body hidden lg:table-cell"><%= main_plan.senior_fee.to_s(:delimited, delimiter: ',') %>円</td>

--- a/app/views/main_plans/show.html.erb
+++ b/app/views/main_plans/show.html.erb
@@ -20,23 +20,21 @@
     <h1 class="page_title">ルーム料金詳細</h1>
     <div id="show_wrapper">
       <div id="plan_title">
-        <p class="bg-yellow-300 px-2 py-2 border-2 border-gray-500 rounded-md"><%= @main_plan.name %></p>
+        <p class="bg-yellow-300 px-2 py-2 border-2 border-gray-500 rounded-md"><%= @main_plan.fee_type_i18n %></p>
       </div>
       <table class="table-auto border-collapse border-2 border-gray-500" id="m_plan_div_table">
         <thead>
           <tr id="table_heading" class="bg-blue-500 text-center text-sm font-bold">
-            <th class="show_div_table_head">区分</th>
             <th class="show_div_table_head">曜日</th>
             <th class="show_div_table_head">時間帯</th>
-            <th class="show_div_table_head">単位</th>
+            <th class="show_div_table_head">区分</th>
           </tr>
         </thead>
         <tbody>
           <tr class="border-b border-gray-200 hover:bg-gray-100  text-center text-sm">
-            <td class="show_div_table_body"><%= @main_plan.div_member_i18n %></td>
             <td class="show_div_table_body"><%= @main_plan.div_day_i18n %></td>
             <td class="show_div_table_body"><%= @main_plan.div_time_i18n %></td>
-            <td class="show_div_table_body"><%= @main_plan.time_unit_i18n %></td>
+            <td class="show_div_table_body"><%= @main_plan.div_member_i18n %></td>
           </tr>
         </tbody>
       </table>

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,7 +1,7 @@
 ja:
   enums:
     main_plan:
-      time_unit:
+      fee_type:
         half_hour_fee: '30分料金'
         three_hour_fee: '3時間パック料金'
         free_time_fee: 'フリータイム料金'

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -2,9 +2,9 @@ ja:
   enums:
     main_plan:
       fee_type:
-        half_hour_fee: '30分料金'
-        three_hour_fee: '3時間パック料金'
-        free_time_fee: 'フリータイム料金'
+        half_hour: '30分料金'
+        three_hour: '3時間パック料金'
+        free_time: 'フリータイム料金'
       div_member:
         other: '一般'
         member: '会員'
@@ -16,10 +16,6 @@ ja:
         day: '昼'
         night: '夜'
         evening: '夕方'
-      time_unit:
-        half_hour: '30分'
-        three_hour: '3時間'
-        free_time: 'フリー'
     drink_plan:
       time_unit:
         half_hour: '30分'
@@ -28,7 +24,7 @@ ja:
         base_half_hour: '30分'
         base_one_hour: '60分'
         base_one_half_hour: '90分'
-        base_free_time: 'フリー'
+        base_free_time: 'フリータイム'
       fee_type:
         drink_bar: 'ドリンクバー料金'
         lite_plan: 'ライト飲み放題料金'

--- a/config/locales/enums.ja.yml
+++ b/config/locales/enums.ja.yml
@@ -1,6 +1,10 @@
 ja:
   enums:
     main_plan:
+      time_unit:
+        half_hour_fee: '30分料金'
+        three_hour_fee: '3時間パック料金'
+        free_time_fee: 'フリータイム料金'
       div_member:
         other: '一般'
         member: '会員'
@@ -15,7 +19,6 @@ ja:
       time_unit:
         half_hour: '30分'
         three_hour: '3時間'
-        four_hour: '4時間'
         free_time: 'フリー'
     drink_plan:
       time_unit:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,7 +7,7 @@ ja:
       user: ユーザー
     attributes:
       main_plan:
-        name: 料金名
+        fee_type: 料金名
         note: 備考
         div_member: 会員区分
         div_day: 曜日区分

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -21,15 +21,15 @@ ja:
         name: 料金名
         note: 備考
         time_unit: 時間単位
-        adult_fee: 一般料金/基本
-        student_fee: 学生料金/基本
-        senior_fee: シニア料金/基本
-        child_fee: 小学生料金/基本
+        adult_fee: 一般/基本料金
+        student_fee: 学生/基本料金
+        senior_fee: シニア/基本料金
+        child_fee: 小学生/基本料金
         base_time: 基本時間
-        extension_adult_fee: 一般料金/延長
-        extension_student_fee: 学生料金/延長
-        extension_senior_fee: シニア料金/延長
-        extension_child_fee: 小学生料金/延長
+        extension_adult_fee: 一般/延長料金
+        extension_student_fee: 学生/延長料金
+        extension_senior_fee: シニア/延長料金
+        extension_child_fee: 小学生/延長料金
         fee_type: 料金種類
       fee_guide:
         div_member: 会員区分

--- a/db/migrate/20210927120144_change_main_plans_columns.rb
+++ b/db/migrate/20210927120144_change_main_plans_columns.rb
@@ -1,0 +1,15 @@
+class ChangeMainPlansColumns < ActiveRecord::Migration[6.1]
+  def up
+    change_table :main_plans, bulk: true do |t|
+      t.remove :name
+      t.integer :fee_type, null: false, default: 0
+    end
+  end
+
+  def down
+    change_table :main_plans, bulk: true do |t|
+      t.string :name
+      t.remove :fee_type
+    end
+  end
+end

--- a/db/migrate/20210927125537_remove_time_unit_from_main_plans.rb
+++ b/db/migrate/20210927125537_remove_time_unit_from_main_plans.rb
@@ -1,0 +1,13 @@
+class RemoveTimeUnitFromMainPlans < ActiveRecord::Migration[6.1]
+  def up
+    change_table :main_plans, bulk: true do |t|
+      t.remove :time_unit
+    end
+  end
+
+  def down
+    change_table :main_plans, bulk: true do |t|
+      t.integer :time_unit
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_27_120144) do
+ActiveRecord::Schema.define(version: 2021_09_27_125537) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,7 +64,6 @@ ActiveRecord::Schema.define(version: 2021_09_27_120144) do
     t.integer "div_member", default: 0, null: false
     t.integer "div_day", default: 0, null: false
     t.integer "div_time", default: 0, null: false
-    t.integer "time_unit", default: 0, null: false
     t.integer "adult_fee", null: false
     t.integer "student_fee", null: false
     t.integer "senior_fee", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_26_081008) do
+ActiveRecord::Schema.define(version: 2021_09_27_120144) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -60,7 +60,6 @@ ActiveRecord::Schema.define(version: 2021_09_26_081008) do
   end
 
   create_table "main_plans", force: :cascade do |t|
-    t.string "name", null: false
     t.text "note"
     t.integer "div_member", default: 0, null: false
     t.integer "div_day", default: 0, null: false
@@ -73,6 +72,7 @@ ActiveRecord::Schema.define(version: 2021_09_26_081008) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "shop_id"
+    t.integer "fee_type", default: 0, null: false
     t.index ["shop_id"], name: "index_main_plans_on_shop_id"
   end
 


### PR DESCRIPTION
### 実装内容
- `MainPlans`テーブルから`name`カラムと`time_unit`カラムを削除
- `MainPlans`テーブルに`fee_type`カラムを追加
  - `fee_type`カラム に`NOTNULL`制約
- カラム変更に伴う、ビューの修正
- カラム変更に伴う、`FeeGuide`モデルの記述修正

### 確認事項
- ローカル環境での動作確認
- `rubocop -a`を実行