### PR TITLE
FeeGuidesテーブルにカラムを追加

### DIFF
--- a/app/controllers/fee_guides_controller.rb
+++ b/app/controllers/fee_guides_controller.rb
@@ -6,7 +6,7 @@ class FeeGuidesController < ApplicationController
   end
 
   def new
-    @fee_guide = FeeGuide.new
+    @fee_guide = Form::FeeGuide.new
     @topics_five = Topic.order(created_at: :desc).limit(5)
     @topics_three = Topic.order(created_at: :desc).limit(3)
     @user = current_user
@@ -15,7 +15,8 @@ class FeeGuidesController < ApplicationController
 
   def create
     binding.pry
-    @fee_guide = FeeGuide.new(fee_guide_params)
+    @fee_guide = Form::FeeGuide.new(fee_guide_params)
+    binding.pry
     @fee_guide.store_calculated_result
     if @fee_guide.save!
       redirect_to edit_fee_guide_url(@fee_guide)
@@ -43,12 +44,11 @@ class FeeGuidesController < ApplicationController
   private
 
   def fee_guide_params
-    params.require(:fee_guide).permit(Form::FeeGuide::REGISTRABLE_ATTRIBUTES)
+    params.require(:form_fee_guide).permit(Form::FeeGuide::REGISTRABLE_ATTRIBUTES)
   end
 
   def fee_guide_update_params
-    params.require(:fee_guide).permit(:div_member, :number_of_adults, :number_of_students, :number_of_seniors, :number_of_children, :usage_time, :drink_plan,
-                                      :number_of_customers, :total_fee, :adult_main_fee, :student_main_fee, :senior_main_fee, :child_main_fee, :adult_drink_fee, :student_drink_fee, :senior_drink_fee, :child_drink_fee, :adult_total_fee, :student_total_fee, :senior_total_fee, :child_total_fee)
+    params.require(:form_fee_guide).permit(Form::FeeGuide::REGISTRABLE_ATTRIBUTES)
   end
 
   def set_fee_guide

--- a/app/controllers/fee_guides_controller.rb
+++ b/app/controllers/fee_guides_controller.rb
@@ -14,6 +14,7 @@ class FeeGuidesController < ApplicationController
   end
 
   def create
+    binding.pry
     @fee_guide = FeeGuide.new(fee_guide_params)
     @fee_guide.store_calculated_result
     if @fee_guide.save!
@@ -42,8 +43,7 @@ class FeeGuidesController < ApplicationController
   private
 
   def fee_guide_params
-    params.require(:fee_guide).permit(:div_member, :number_of_adults, :number_of_students, :number_of_seniors, :number_of_children, :usage_time,
-                                      :drink_plan)
+    params.require(:fee_guide).permit(Form::FeeGuide::REGISTRABLE_ATTRIBUTES)
   end
 
   def fee_guide_update_params

--- a/app/javascript/datepicker.js
+++ b/app/javascript/datepicker.js
@@ -1,7 +1,7 @@
 document.addEventListener('turbolinks:load', function () {
   $(function () {
     $('#datepicker').datepicker({
-      dateFormat: 'yy-mm-dd',
+      dateFormat: 'yy年mm月dd日',
     });
   });
 });

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1460,11 +1460,41 @@ p {
     }
   }
 }
-#fee_guide_select {
+#fee_guide_select,
+#fee_guide_select_shop {
   select {
     font-size: 16px;
     width: 200px;
     height: 40px;
+    padding-left: 5px;
+    padding-bottom: 2px;
+    background: white;
+    border: gray 1px solid;
+    border-radius: 8px;
+  }
+}
+#fee_guide_select_shop {
+  select {
+    width: 300px;
+  }
+}
+#fee_guide_datetime {
+  input {
+    font-size: 16px;
+    width: 150px;
+    height: 40px;
+    padding-left: 5px;
+    padding-bottom: 2px;
+    background: white;
+    border: gray 1px solid;
+    border-radius: 8px;
+  }
+  select {
+    font-size: 16px;
+    width: 60px;
+    height: 40px;
+    margin-left: 10px;
+    margin-right: 5px;
     padding-left: 5px;
     padding-bottom: 2px;
     background: white;
@@ -1785,4 +1815,9 @@ p {
     border-right: 15px solid transparent;
     border-bottom: 15px solid #ff5500;
   }
+}
+
+// datepicker
+ui-datepicker-header {
+  background: chocolate;
 }

--- a/app/models/concerns/datetime_integratable.rb
+++ b/app/models/concerns/datetime_integratable.rb
@@ -1,0 +1,51 @@
+module DatetimeIntegratable
+  extend ActiveSupport::Concern
+
+  included do
+    after_initialize :initialize_integrate_datetime
+    before_validation :integrate_datetime
+
+    def initialize_integrate_datetime
+      self.class.datetime_integrate_targets.each do |attribute|
+        next unless respond_to?(attribute.to_s)
+
+        original_date = send(attribute.to_s)
+        next if original_date.nil?
+
+        [["date", "%Y/%m/%d"], ["hour", "%H"], ["minute", "%M"]].each do |key, format|
+          next if send("#{attribute}_#{key}").present?
+
+          send("#{attribute}_#{key}=", original_date.strftime(format))
+        end
+      end
+    end
+
+    def integrate_datetime
+      self.class.datetime_integrate_targets.each do |attribute|
+        date = send("#{attribute}_date")
+        hour = send("#{attribute}_hour")
+        minute = send("#{attribute}_minute")
+        if date.present? && hour.present? && minute.present?
+          send("#{attribute}=", Time.zone.parse("#{date} #{hour}:#{minute}:00"))
+        else
+          send("#{attribute}=", nil)
+        end
+      end
+    rescue StandardError
+      nil
+    end
+  end
+
+  module ClassMethods
+    attr_accessor :datetime_integrate_targets
+
+    def integrate_datetime_fields(*attributes)
+      self.datetime_integrate_targets = attributes
+      attributes.each do |attribute|
+        send(:attr_accessor, "#{attribute}_date")
+        send(:attr_accessor, "#{attribute}_hour")
+        send(:attr_accessor, "#{attribute}_minute")
+      end
+    end
+  end
+end

--- a/app/models/fee_guide.rb
+++ b/app/models/fee_guide.rb
@@ -1,6 +1,7 @@
 require "date"
 
 class FeeGuide < ApplicationRecord
+  belongs_to :shop
   with_options presence: true do
     validates :div_member
     validates :usage_time

--- a/app/models/form/fee_guide.rb
+++ b/app/models/form/fee_guide.rb
@@ -1,0 +1,35 @@
+class Form::FeeGuide < FeeGuide
+  include DatetimeIntegratable
+
+  REGISTRABLE_ATTRIBUTES = %i[
+    div_member
+    usage_time
+    drink_plan
+    number_of_adults
+    number_of_students
+    number_of_seniors
+    number_of_children
+    number_of_customers
+    total_fee
+    adult_main_fee
+    student_main_fee
+    senior_main_fee
+    child_main_fee
+    adult_drink_fee
+    student_drink_fee
+    senior_drink_fee
+    child_drink_fee
+    adult_total_fee
+    student_total_fee
+    senior_total_fee
+    child_total_fee
+    shop_id
+    start_time
+  ]
+
+  integrate_datetime_fields :start_time
+
+  validates :start_time_date, presence: true
+  validates :start_time_hour, presence: true
+  validates :start_time_minute, presence: true
+end

--- a/app/models/form/fee_guide.rb
+++ b/app/models/form/fee_guide.rb
@@ -24,7 +24,9 @@ class Form::FeeGuide < FeeGuide
     senior_total_fee
     child_total_fee
     shop_id
-    start_time
+    start_time_date
+    start_time_hour
+    start_time_minute
   ]
 
   integrate_datetime_fields :start_time

--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -2,6 +2,7 @@ class Shop < ApplicationRecord
   has_many :main_plans, dependent: :destroy
   has_many :drink_plans, dependent: :destroy
   has_many :topics, dependent: :destroy
+  has_many :fee_guides, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/fee_guides/_form_fee_guide.html.erb
+++ b/app/views/fee_guides/_form_fee_guide.html.erb
@@ -8,7 +8,7 @@
         </p>
         <p class="hidden sm:block text-base md:text-lg px-2 sm:mb-1" id="step_title">ご利用店舗を選んでください</p>       
       </div>
-      <div class="px-2 ml-2 mt-6 sm:mt-0 mb-4 xl:mb-3" id="fee_guide_select">
+      <div class="px-2 ml-2 mt-6 sm:mt-0 mb-4 xl:mb-3" id="fee_guide_select_shop">
         <%= f.collection_select :shop_id, Shop.all, :id, :name %>
       </div>
     </div>
@@ -20,8 +20,10 @@
         </p>
         <p class="hidden sm:block text-base md:text-lg px-2 sm:mb-1" id="step_title">入室予定時刻を選んでください</p>       
       </div>
-      <div class="px-2 ml-2 mt-6 sm:mt-0 mb-4 xl:mb-3" id="fee_guide_select">
-          <%= f.text_field :start_time, id:"datepicker" %>
+      <div class="px-2 ml-2 mt-6 sm:mt-0 mb-4 xl:mb-3" id="fee_guide_datetime">
+          <%= f.text_field :start_time_date, id:"datepicker" %>
+          <%= f.select :start_time_hour, [["10", 10],["11", 11], ["12", 12], ["13", 13],["14", 14],["15", 15],["16", 16],["17", 17],["18", 18],["19", 19],["20", 20],["21", 21],["22", 22],["23", 23],["00", 24],["01", 25],["02", 26],["03", 27]], {class: "mx-2 bg-white", id: "num_customers", required: true} %><span>時</span>
+          <%= f.select :start_time_minutes, [["00", 0],["15", 15], ["30", 30], ["45", 45]], {class: "mx-2 bg-white", id: "num_customers", required: true} %><span>分</span>
       </div>
     </div>
     <div class="px-3 pt-4 pb-2 sm:px-2 sm:pb-2 rounded hover:bg-yellow-600 hover:bg-opacity-10">

--- a/app/views/fee_guides/_form_fee_guide.html.erb
+++ b/app/views/fee_guides/_form_fee_guide.html.erb
@@ -1,5 +1,5 @@
 <div class="mx-1 mt-4 sm:my-0 sm:mb-0 sm:mx-auto xl:mx-0 pt-2 sm:p-4 border-2 border-app text-sm rounded-2xl bg-white" id="fee_guide_form">
-  <%= form_with model: @fee_guide, local: true do |f| %>
+  <%= form_for(@fee_guide, url: path, method: method) do |f| %>
     <div class="px-3 pt-4 pb-3 sm:px-2 sm:pb-2 rounded-md hover:bg-yellow-600 hover:bg-opacity-10 ">
       <div class="sm:flex items-center mb-3">
         <p class="text-base  bg-app px-2 py-1 rounded-lg shadow font-black pl-3 sm:pl-2 sm:mb-1 sm:mr-0.5 text-white" id="step_num">
@@ -23,7 +23,7 @@
       <div class="px-2 ml-2 mt-6 sm:mt-0 mb-4 xl:mb-3" id="fee_guide_datetime">
           <%= f.text_field :start_time_date, id:"datepicker" %>
           <%= f.select :start_time_hour, [["10", 10],["11", 11], ["12", 12], ["13", 13],["14", 14],["15", 15],["16", 16],["17", 17],["18", 18],["19", 19],["20", 20],["21", 21],["22", 22],["23", 23],["00", 24],["01", 25],["02", 26],["03", 27]], {class: "mx-2 bg-white", id: "num_customers", required: true} %><span>時</span>
-          <%= f.select :start_time_minutes, [["00", 0],["15", 15], ["30", 30], ["45", 45]], {class: "mx-2 bg-white", id: "num_customers", required: true} %><span>分</span>
+          <%= f.select :start_time_minute, [["00", 0],["15", 15], ["30", 30], ["45", 45]], {class: "mx-2 bg-white", id: "num_customers", required: true} %><span>分</span>
       </div>
     </div>
     <div class="px-3 pt-4 pb-2 sm:px-2 sm:pb-2 rounded hover:bg-yellow-600 hover:bg-opacity-10">

--- a/app/views/fee_guides/new.html.erb
+++ b/app/views/fee_guides/new.html.erb
@@ -118,7 +118,7 @@
 
 <div id="modal" class="mx-auto xl:flex items-center justify-evenly flex-row-reverse bg-black bg-opacity-80 transform scale-0 transition-transform duration-300 py-2 px-2 sm:px-4 sm:py-12">
   <div class="flex justify-center">
-    <%= render "form_fee_guide" %>
+    <%= render 'form_fee_guide', path: fee_guides_path, method: :post %>
   </div>
   <div class="w-11/12 xl:w-auto mt-8 xl:mt-0 sm:max-w-screen-sm mx-auto xl:mx-0">
     <h3 class="text-2xl text-center text-white mb-3">よくあるご質問</h3>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
     <%= stylesheet_pack_tag "application", "data-turbo-track": "reload" %>
     <script src="https://rawgit.com/jquery/jquery-ui/master/ui/i18n/datepicker-ja.js"></script>
     <link href="https://use.fontawesome.com/releases/v5.15.1/css/all.css" rel="stylesheet">
+    <link rel="stylesheet" href="//code.jquery.com/ui/1.12.1/themes/base/jquery-ui.css">
     <script type="text/javascript">
       $(window).bind("unload",function(){});
     </script>

--- a/db/migrate/20211003091212_add_columns_to_fee_guides2.rb
+++ b/db/migrate/20211003091212_add_columns_to_fee_guides2.rb
@@ -1,0 +1,8 @@
+class AddColumnsToFeeGuides2 < ActiveRecord::Migration[6.1]
+  def change
+    change_table :fee_guides, bulk: true do |t|
+      t.references :shop, foreign_key: true
+      t.datetime :start_time
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_29_054057) do
+ActiveRecord::Schema.define(version: 2021_10_03_091212) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -59,6 +59,9 @@ ActiveRecord::Schema.define(version: 2021_09_29_054057) do
     t.integer "student_total_fee", null: false
     t.integer "senior_total_fee", null: false
     t.integer "child_total_fee", null: false
+    t.bigint "shop_id"
+    t.datetime "start_time"
+    t.index ["shop_id"], name: "index_fee_guides_on_shop_id"
   end
 
   create_table "main_plans", force: :cascade do |t|
@@ -136,6 +139,7 @@ ActiveRecord::Schema.define(version: 2021_09_29_054057) do
   end
 
   add_foreign_key "drink_plans", "shops"
+  add_foreign_key "fee_guides", "shops"
   add_foreign_key "main_plans", "shops"
   add_foreign_key "topics", "shops"
 end


### PR DESCRIPTION
### 実装内容
- 料金案内に利用店舗(shop_id)・開始日時(start_time)のカラムを追加
- 上記を登録できるようにコントローラとモデルを修正

### 確認事項
ローカル環境で動作を確認